### PR TITLE
DrivebaseController: Add DrivebaseController

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,1 +1,63 @@
-/opt/ros/kinetic/share/catkin/cmake/toplevel.cmake
+# toplevel CMakeLists.txt for a catkin workspace
+# catkin/cmake/toplevel.cmake
+
+cmake_minimum_required(VERSION 2.8.3)
+
+set(CATKIN_TOPLEVEL TRUE)
+
+# search for catkin within the workspace
+set(_cmd "catkin_find_pkg" "catkin" "${CMAKE_SOURCE_DIR}")
+execute_process(COMMAND ${_cmd}
+  RESULT_VARIABLE _res
+  OUTPUT_VARIABLE _out
+  ERROR_VARIABLE _err
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  ERROR_STRIP_TRAILING_WHITESPACE
+)
+if(NOT _res EQUAL 0 AND NOT _res EQUAL 2)
+  # searching fot catkin resulted in an error
+  string(REPLACE ";" " " _cmd_str "${_cmd}")
+  message(FATAL_ERROR "Search for 'catkin' in workspace failed (${_cmd_str}): ${_err}")
+endif()
+
+# include catkin from workspace or via find_package()
+if(_res EQUAL 0)
+  set(catkin_EXTRAS_DIR "${CMAKE_SOURCE_DIR}/${_out}/cmake")
+  # include all.cmake without add_subdirectory to let it operate in same scope
+  include(${catkin_EXTRAS_DIR}/all.cmake NO_POLICY_SCOPE)
+  add_subdirectory("${_out}")
+
+else()
+  # use either CMAKE_PREFIX_PATH explicitly passed to CMake as a command line argument
+  # or CMAKE_PREFIX_PATH from the environment
+  if(NOT DEFINED CMAKE_PREFIX_PATH)
+    if(NOT "$ENV{CMAKE_PREFIX_PATH}" STREQUAL "")
+      string(REPLACE ":" ";" CMAKE_PREFIX_PATH $ENV{CMAKE_PREFIX_PATH})
+    endif()
+  endif()
+
+  # list of catkin workspaces
+  set(catkin_search_path "")
+  foreach(path ${CMAKE_PREFIX_PATH})
+    if(EXISTS "${path}/.catkin")
+      list(FIND catkin_search_path ${path} _index)
+      if(_index EQUAL -1)
+        list(APPEND catkin_search_path ${path})
+      endif()
+    endif()
+  endforeach()
+
+  # search for catkin in all workspaces
+  set(CATKIN_TOPLEVEL_FIND_PACKAGE TRUE)
+  find_package(catkin QUIET
+    NO_POLICY_SCOPE
+    PATHS ${catkin_search_path}
+    NO_DEFAULT_PATH NO_CMAKE_FIND_ROOT_PATH)
+  unset(CATKIN_TOPLEVEL_FIND_PACKAGE)
+
+  if(NOT catkin_FOUND)
+    message(FATAL_ERROR "find_package(catkin) failed. catkin was neither found in the workspace nor in the CMAKE_PREFIX_PATH. One reason may be that no ROS setup.sh was sourced before.")
+  endif()
+endif()
+
+catkin_workspace()

--- a/src/tfr_control/CMakeLists.txt
+++ b/src/tfr_control/CMakeLists.txt
@@ -40,19 +40,43 @@ include_directories(
 )
 
 # Create executable process/node and link it
-add_executable(proto_driver_station src/proto_driver_station.cpp)
-target_link_libraries(proto_driver_station ${catkin_LIBRARIES} sfml-system
-                        sfml-window sfml-graphics)
+add_executable(proto_driver_station 
+  src/proto_driver_station.cpp
+)
 
-add_executable(controller_launcher src/controller_launcher.cpp
-                                   src/controller.cpp)
-target_link_libraries(controller_launcher ${catkin_LIBRARIES})
+target_link_libraries(proto_driver_station
+  ${catkin_LIBRARIES} 
+  sfml-system
+  sfml-window sfml-graphics
+)
+
+add_executable(controller_launcher
+  src/controller_launcher.cpp
+  src/controller.cpp
+)
+
+target_link_libraries(controller_launcher
+  ${catkin_LIBRARIES}
+)
+
+add_executable(drivebase
+  src/drivebase.cpp
+  src/drivebase_publisher.cpp
+)
+
+target_link_libraries(drivebase
+  ${catkin_LIBRARIES}
+)
 
 # This call is sometimes needed and sometimes not and I'm not really clear why
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 # Add gtest based cpp test target and link libraries
-catkin_add_gtest(${PROJECT_NAME}-test test/test_tfr_control.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test)
-# endif()
+catkin_add_gtest(${PROJECT_NAME}-test
+  test/test_tfr_control.cpp
+  src/drivebase_publisher.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}-test
+  ${catkin_LIBRARIES}
+)

--- a/src/tfr_control/include/tfr_control/drivebase_publisher.h
+++ b/src/tfr_control/include/tfr_control/drivebase_publisher.h
@@ -1,0 +1,57 @@
+/****************************************************************************************
+ * File:            drivebase_publisher.h
+ * 
+ * Purpose:         This class is used by the drivebase node to convert from a Twist
+ *                  message in /cmd_vel to angular velocity for the two motor sets
+ *                  (left and right), handling the calculations for differential steering.
+ * 
+ *                  Every message read from /cmd_vel will result in two messages sent,
+ *                  one to each motor controller. This class will only publish after
+ *                  reading a message on /cmd_vel.
+ * 
+ * Subscribed To:   /cmd_vel
+ * Publishes To:    /left_tread_velocity_controller/command
+ *                  /right_tread_velocity_controller/command
+ ***************************************************************************************/
+#ifndef DRIVEBASE_PUBLISHER_H
+#define DRIVEBASE_PUBLISHER_H
+
+#include "ros/ros.h"
+#include "geometry_msgs/Twist.h"
+
+namespace tfr_control
+{
+    class DrivebasePublisher
+    {
+    public:
+        DrivebasePublisher() = delete;
+        explicit DrivebasePublisher(ros::NodeHandle& n, float axle_length, float wheel_radius);
+        DrivebasePublisher(const DrivebasePublisher& other) = delete;
+        DrivebasePublisher(DrivebasePublisher&&) = delete;
+
+        ~DrivebasePublisher() = default;
+
+        DrivebasePublisher& operator=(const DrivebasePublisher&) = delete;
+        DrivebasePublisher& operator=(DrivebasePublisher&&) = delete;
+        
+
+        // Making this static allows for unit-testing without 
+        // creating a DrivebasePublisher object
+        // left_tread and right_tread are output parameters; the rest are inputs.
+        static void twistToDifferential(float linear_v, float angular_v, float wheel_radius, 
+                                        float axle_length, float& left_tread, float& right_tread);
+
+    private:
+        void subscriptionCallback(const geometry_msgs::Twist::ConstPtr& msg);
+
+        ros::NodeHandle& n;
+        float wheel_radius;
+        float axle_length;
+
+        ros::Publisher left_tread_publisher;
+        ros::Publisher right_tread_publisher;
+        ros::Subscriber subscriber;
+    };
+}
+
+#endif // DRIVEBASE_PUBLISHER_H

--- a/src/tfr_control/include/tfr_control/drivebase_publisher.h
+++ b/src/tfr_control/include/tfr_control/drivebase_publisher.h
@@ -25,7 +25,7 @@ namespace tfr_control
     {
     public:
         DrivebasePublisher() = delete;
-        explicit DrivebasePublisher(ros::NodeHandle& n, float axle_length, float wheel_radius);
+        explicit DrivebasePublisher(ros::NodeHandle& n, float wheel_span, float wheel_radius);
         DrivebasePublisher(const DrivebasePublisher& other) = delete;
         DrivebasePublisher(DrivebasePublisher&&) = delete;
 
@@ -38,15 +38,15 @@ namespace tfr_control
         // Making this static allows for unit-testing without 
         // creating a DrivebasePublisher object
         // left_tread and right_tread are output parameters; the rest are inputs.
-        static void twistToDifferential(float linear_v, float angular_v, float wheel_radius, 
-                                        float axle_length, float& left_tread, float& right_tread);
+        static void twistToDifferential(const float linear_v, const float angular_v, const float wheel_radius, 
+                                        const float wheel_span, float& left_tread, float& right_tread);
 
     private:
         void subscriptionCallback(const geometry_msgs::Twist::ConstPtr& msg);
 
         ros::NodeHandle& n;
-        float wheel_radius;
-        float axle_length;
+        const float wheel_radius;
+        const float wheel_span;
 
         ros::Publisher left_tread_publisher;
         ros::Publisher right_tread_publisher;

--- a/src/tfr_control/launch/drivebase.launch
+++ b/src/tfr_control/launch/drivebase.launch
@@ -1,5 +1,5 @@
 <launch>
-  <param name="axle_length"  value="0.9906"/> <!-- Length in meters -->
+  <param name="wheel_span"  value="0.9906"/> <!-- Length in meters -->
   <param name="wheel_radius" value="0.14605"/> <!-- Radius in meters -->
 
   <node pkg="tfr_control" type="drivebase" name="drivebase"/>

--- a/src/tfr_control/launch/drivebase.launch
+++ b/src/tfr_control/launch/drivebase.launch
@@ -1,0 +1,6 @@
+<launch>
+  <param name="axle_length"  value="0.9906"/> <!-- Length in meters -->
+  <param name="wheel_radius" value="0.14605"/> <!-- Radius in meters -->
+
+  <node pkg="tfr_control" type="drivebase" name="drivebase"/>
+</launch>

--- a/src/tfr_control/src/drivebase.cpp
+++ b/src/tfr_control/src/drivebase.cpp
@@ -1,0 +1,27 @@
+/****************************************************************************************
+ * File:            drivebase.cpp
+ * 
+ * Purpose:         This node converts Twist data from the /cmd_vel topic to angular
+ *                  velocity of the two motor sets (left and right). Most of the
+ *                  responsibilities are delegated to the DrivebasePublisher class.
+ * 
+ * Launched By:     drivebase.launch
+ ***************************************************************************************/
+#include "ros/ros.h"
+#include "drivebase_publisher.h"
+
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "drivebase");
+
+    ros::NodeHandle n;
+    float axle_length, wheel_radius;
+    n.getParam("axle_length", axle_length);
+    n.getParam("wheel_radius", wheel_radius);
+    
+    tfr_control::DrivebasePublisher publisher(n, axle_length, wheel_radius);
+
+    ros::spin();
+    return 0;
+}

--- a/src/tfr_control/src/drivebase.cpp
+++ b/src/tfr_control/src/drivebase.cpp
@@ -16,11 +16,32 @@ int main(int argc, char **argv)
     ros::init(argc, argv, "drivebase");
 
     ros::NodeHandle n;
-    float axle_length, wheel_radius;
-    n.getParam("axle_length", axle_length);
-    n.getParam("wheel_radius", wheel_radius);
+    float wheel_span, wheel_radius;
+    if (!n.getParam("wheel_span", wheel_span))
+    {
+        // Parameter error
+        ROS_ERROR("Parameter 'wheel_span' not found for node 'drivebase'");
+        return 1;
+    }
+    else if (wheel_span <= 0)
+    {
+        ROS_ERROR("Parameter 'wheel_span' must be a positive value.");
+        return 1;
+    }
+
+    if (!n.getParam("wheel_radius", wheel_radius))
+    {
+        // Parameter error
+        ROS_ERROR("Parameter 'wheel_radius' not found for node 'drivebase'");
+        return 1;
+    }
+    else if (wheel_radius <= 0)
+    {
+        ROS_ERROR("Parameter 'wheel_radius' must be a positive value.");
+        return 1;
+    }
     
-    tfr_control::DrivebasePublisher publisher(n, axle_length, wheel_radius);
+    tfr_control::DrivebasePublisher publisher(n, wheel_span, wheel_radius);
 
     ros::spin();
     return 0;

--- a/src/tfr_control/src/drivebase_publisher.cpp
+++ b/src/tfr_control/src/drivebase_publisher.cpp
@@ -1,0 +1,54 @@
+/****************************************************************************************
+ * File:            drivebase_publisher.cpp
+ * 
+ * Purpose:         This is the implementation file for the DrivebasePublisher class.
+ *                  See tfr_control/include/tfr_control/drivebase_publisher.h for details.
+ ***************************************************************************************/
+#include "drivebase_publisher.h"
+#include "std_msgs/Float64.h"
+
+namespace tfr_control
+{
+    DrivebasePublisher::DrivebasePublisher(
+        ros::NodeHandle& n, float wheel_radius, float axle_length) : 
+        n{n}, wheel_radius{wheel_radius}, axle_length{axle_length}, 
+        left_tread_publisher{}, right_tread_publisher{}
+    {
+        left_tread_publisher = n.advertise<std_msgs::Float64>(
+            "left_tread_velocity_controller/command", 100);
+
+        right_tread_publisher = n.advertise<std_msgs::Float64>(
+            "right_tread_velocity_controller/command", 100);
+
+        subscriber = n.subscribe("cmd_vel", 100, &DrivebasePublisher::subscriptionCallback, this);
+    }
+
+    void DrivebasePublisher::subscriptionCallback(const geometry_msgs::Twist::ConstPtr& msg)
+    {
+        float left_tread, right_tread;
+
+        DrivebasePublisher::twistToDifferential(msg->linear.x, msg->angular.z,
+            this->axle_length, this->wheel_radius, left_tread, right_tread);
+        
+        std_msgs::Float64 left_msg;
+        std_msgs::Float64 right_msg;
+        left_msg.data = left_tread;
+        right_msg.data = right_tread;
+        left_tread_publisher.publish(left_msg);
+        right_tread_publisher.publish(right_msg);
+    }
+
+    // left_tread and right_tread are output parameters; the rest are inputs.
+    void DrivebasePublisher::twistToDifferential(float linear_v, float angular_v,
+        float wheel_radius, float axle_length, float& left_tread, float& right_tread)
+    {
+        // Desired velocity across the ground for each wheel
+        float left_velocity = linear_v - (axle_length * angular_v) / 2;
+        float right_velocity = linear_v + (axle_length * angular_v) / 2;
+
+        // Convert linear velocity to angular velocity of the wheel
+        left_tread = left_velocity / wheel_radius;
+        right_tread = right_velocity / wheel_radius;
+    }
+
+}

--- a/src/tfr_control/test/test_tfr_control.cpp
+++ b/src/tfr_control/test/test_tfr_control.cpp
@@ -4,6 +4,54 @@
  * This is the main test class for the tfr_control package.
  */
 #include <gtest/gtest.h>
+#include "drivebase_publisher.h"
+
+using tfr_control::DrivebasePublisher;
+
+TEST(Control, Drivebase)
+{
+    // Google tests provide no handlers for exceptions
+    try
+    {
+        const float WHEEL_RADIUS = 0.14605;
+        const float AXLE_LENGTH = 0.9906;
+        const float ABS_ERROR = 0.00005;
+        float left_tread = 0;
+        float right_tread = 0;
+
+        DrivebasePublisher::twistToDifferential(0, 0, WHEEL_RADIUS, 
+                              AXLE_LENGTH, left_tread, right_tread);
+        EXPECT_EQ(0, left_tread);
+        EXPECT_EQ(0, right_tread);
+
+        DrivebasePublisher::twistToDifferential(10, 0, WHEEL_RADIUS, 
+                              AXLE_LENGTH, left_tread, right_tread);
+        EXPECT_NEAR(68.46970216, left_tread, ABS_ERROR);
+        EXPECT_NEAR(68.46970216, right_tread, ABS_ERROR);
+        EXPECT_EQ(left_tread, right_tread);
+
+        DrivebasePublisher::twistToDifferential(10, 3.1415, WHEEL_RADIUS, 
+                              AXLE_LENGTH, left_tread, right_tread);
+        EXPECT_NEAR(57.81591955, left_tread, ABS_ERROR);
+        EXPECT_NEAR(79.12348477, right_tread, ABS_ERROR);
+
+        DrivebasePublisher::twistToDifferential(2, 3.1415, WHEEL_RADIUS, 
+                              AXLE_LENGTH, left_tread, right_tread);
+        EXPECT_NEAR(3.040157823, left_tread, ABS_ERROR);
+        EXPECT_NEAR(24.34772304, right_tread, ABS_ERROR);
+
+        DrivebasePublisher::twistToDifferential(1.819346, 5.10293874, WHEEL_RADIUS, 
+                              AXLE_LENGTH, left_tread, right_tread);
+        EXPECT_NEAR(-4.848610462, left_tread, ABS_ERROR);
+        EXPECT_NEAR(29.76262621, right_tread, ABS_ERROR);
+
+    }
+    catch (std::exception e)
+    {
+        // An unhandled exception was thrown; fail the test
+        ASSERT_TRUE(false);
+    }
+}
 
 int main(int argc, char **argv)
 {

--- a/src/tfr_control/test/test_tfr_control.cpp
+++ b/src/tfr_control/test/test_tfr_control.cpp
@@ -14,36 +14,87 @@ TEST(Control, Drivebase)
     try
     {
         const float WHEEL_RADIUS = 0.14605;
-        const float AXLE_LENGTH = 0.9906;
+        const float WHEEL_SPAN = 0.9906;
         const float ABS_ERROR = 0.00005;
         float left_tread = 0;
         float right_tread = 0;
 
         DrivebasePublisher::twistToDifferential(0, 0, WHEEL_RADIUS, 
-                              AXLE_LENGTH, left_tread, right_tread);
+                              WHEEL_SPAN, left_tread, right_tread);
         EXPECT_EQ(0, left_tread);
         EXPECT_EQ(0, right_tread);
 
         DrivebasePublisher::twistToDifferential(10, 0, WHEEL_RADIUS, 
-                              AXLE_LENGTH, left_tread, right_tread);
+                              WHEEL_SPAN, left_tread, right_tread);
         EXPECT_NEAR(68.46970216, left_tread, ABS_ERROR);
         EXPECT_NEAR(68.46970216, right_tread, ABS_ERROR);
         EXPECT_EQ(left_tread, right_tread);
 
         DrivebasePublisher::twistToDifferential(10, 3.1415, WHEEL_RADIUS, 
-                              AXLE_LENGTH, left_tread, right_tread);
+                              WHEEL_SPAN, left_tread, right_tread);
         EXPECT_NEAR(57.81591955, left_tread, ABS_ERROR);
         EXPECT_NEAR(79.12348477, right_tread, ABS_ERROR);
 
         DrivebasePublisher::twistToDifferential(2, 3.1415, WHEEL_RADIUS, 
-                              AXLE_LENGTH, left_tread, right_tread);
+                              WHEEL_SPAN, left_tread, right_tread);
         EXPECT_NEAR(3.040157823, left_tread, ABS_ERROR);
         EXPECT_NEAR(24.34772304, right_tread, ABS_ERROR);
 
         DrivebasePublisher::twistToDifferential(1.819346, 5.10293874, WHEEL_RADIUS, 
-                              AXLE_LENGTH, left_tread, right_tread);
+                              WHEEL_SPAN, left_tread, right_tread);
         EXPECT_NEAR(-4.848610462, left_tread, ABS_ERROR);
         EXPECT_NEAR(29.76262621, right_tread, ABS_ERROR);
+
+
+
+
+        DrivebasePublisher::twistToDifferential(10, -3.1415, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(79.12348477, left_tread, ABS_ERROR);
+        EXPECT_NEAR(57.81591955, right_tread, ABS_ERROR);
+
+        DrivebasePublisher::twistToDifferential(2, -3.1415, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(24.3477230, left_tread, ABS_ERROR);
+        EXPECT_NEAR(3.0401578234, right_tread, ABS_ERROR);
+
+        DrivebasePublisher::twistToDifferential(1.819346, -5.10293874, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(29.76262621, left_tread, ABS_ERROR);
+        EXPECT_NEAR(-4.848610462, right_tread, ABS_ERROR);
+
+
+
+        DrivebasePublisher::twistToDifferential(-10, 3.1415, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(-79.12348477, left_tread, ABS_ERROR);
+        EXPECT_NEAR(-57.81591955, right_tread, ABS_ERROR);
+
+        DrivebasePublisher::twistToDifferential(-2, 3.1415, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(-24.3477230, left_tread, ABS_ERROR);
+        EXPECT_NEAR(-3.0401578234, right_tread, ABS_ERROR);
+
+        DrivebasePublisher::twistToDifferential(-1.819346, 5.10293874, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(-29.76262621, left_tread, ABS_ERROR);
+        EXPECT_NEAR(4.848610462, right_tread, ABS_ERROR);
+
+
+        DrivebasePublisher::twistToDifferential(-10, -3.1415, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(-57.81591955, left_tread, ABS_ERROR);
+        EXPECT_NEAR(-79.12348477, right_tread, ABS_ERROR);
+
+        DrivebasePublisher::twistToDifferential(-2, -3.1415, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(-3.0401578234, left_tread, ABS_ERROR);
+        EXPECT_NEAR(-24.3477230, right_tread, ABS_ERROR);
+
+        DrivebasePublisher::twistToDifferential(-1.819346, -5.10293874, WHEEL_RADIUS, 
+                              WHEEL_SPAN, left_tread, right_tread);
+        EXPECT_NEAR(4.848610462, left_tread, ABS_ERROR);
+        EXPECT_NEAR(-29.76262621, right_tread, ABS_ERROR);
 
     }
     catch (std::exception e)


### PR DESCRIPTION
- drivebase.cpp is a node launched with drivebase.launch. It uses
  a DrivebasePublisher class to convert Twist messages to differential
  steering angular velocity values for the two motor sets.

- Add unit tests for twistToDifferential() function

- Regenerated top-level CMakeLists.txt file --- I couldn't build the
  project with the CMakeLists file that is on master; deleting it and
  regenerating it with catkin_make fixed the problem.

- Reorganized tfr_control/CMakeLists.txt to make it easier to read