### PR TITLE
Navigation Action Server

### DIFF
--- a/build_all
+++ b/build_all
@@ -33,5 +33,4 @@ else
 	echo ""
 	exit 1
 fi
-
 . ./devel/setup.sh

--- a/src/tfr_launch/launch/navigation_as_test.launch
+++ b/src/tfr_launch/launch/navigation_as_test.launch
@@ -1,0 +1,6 @@
+<launch>
+    <include file="$(find tfr_launch)/launch/core.launch"/>
+    <include file="$(find tfr_navigation)/launch/action_client.launch"/>
+    <include file="$(find tfr_navigation)/launch/action_server.launch"/>
+
+</launch>

--- a/src/tfr_msgs/CMakeLists.txt
+++ b/src/tfr_msgs/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   geometry_msgs
   actionlib_msgs
+  geometry_msgs
   actionlib
 )
 

--- a/src/tfr_msgs/CMakeLists.txt
+++ b/src/tfr_msgs/CMakeLists.txt
@@ -28,6 +28,7 @@ add_message_files(
 add_action_files(
   FILES
   Example.action
+  Navigation.action
 )
 
 # Generate added messages and services with any dependencies listed here

--- a/src/tfr_msgs/action/Navigation.action
+++ b/src/tfr_msgs/action/Navigation.action
@@ -1,12 +1,22 @@
 #goal msg
-uint8 cmd_code
-uint8 TO_MINING = 0 #Navigate to the mining zone
-uint8 TO_DUMPING = 1 #Navigate to the dumping zone
+Header header
+uint8 location_code
+uint8 UNSET = 0 #not specified yet by the user
+uint8 TO_MINING = 1 #Navigate to the mining zone
+uint8 TO_DUMPING = 2 #Navigate to the dumping zone
 ---
 #feedback msg
+Header header
 uint8 status
 uint8 OK = 0
+uint8 ERROR = 1
+geometry_msgs/Pose current
+geometry_msgs/Pose goal
 ---
 #result msg 
+Header header
 uint8 status
 uint8 OK = 0
+uint8 FAILURE = 1
+geometry_msgs/Pose current
+geometry_msgs/Pose goal

--- a/src/tfr_msgs/action/Navigation.action
+++ b/src/tfr_msgs/action/Navigation.action
@@ -1,9 +1,9 @@
 #goal msg
 Header header
 uint8 location_code
-uint8 UNSET = 0 #not specified yet by the user
-uint8 TO_MINING = 1 #Navigate to the mining zone
-uint8 TO_DUMPING = 2 #Navigate to the dumping zone
+uint8 UNSET = 0
+uint8 TO_MINING = 1
+uint8 TO_DUMPING = 2
 ---
 #feedback msg
 Header header

--- a/src/tfr_msgs/action/Navigation.action
+++ b/src/tfr_msgs/action/Navigation.action
@@ -1,0 +1,12 @@
+#goal msg
+uint8 cmd_code
+uint8 TO_MINING = 0 #Navigate to the mining zone
+uint8 TO_DUMPING = 1 #Navigate to the dumping zone
+---
+#feedback msg
+uint8 status
+uint8 OK = 0
+---
+#result msg 
+uint8 status
+uint8 OK = 0

--- a/src/tfr_navigation/CMakeLists.txt
+++ b/src/tfr_navigation/CMakeLists.txt
@@ -8,14 +8,10 @@ find_package(catkin REQUIRED COMPONENTS
   tfr_msgs
   geometry_msgs
   nav_msgs
-  std_msgs
   actionlib
 )
 
 find_package(GTest REQUIRED)
-
-catkin_package(
-)
 
 include_directories(
     include/${PROJECT_NAME}
@@ -23,28 +19,45 @@ include_directories(
     ${GTEST_INCLUDE_DIRS}
 )
 
-add_library(navigation_goal_manager src/navigation_goal_manager.cpp)
-target_link_libraries(navigation_goal_manager ${catkin_LIBRARIES}) 
+catkin_package(
+    INCLUDE_DIRS include/${PROJECT_NAME}
+    LIBRARIES ${PROJECT_NAME} navigation_server navigation_client
+    CATKIN_DEPENDS  roscpp tfr_msgs actionlib nav_msgs geometry_msgs
+)
+
+
+
+
+add_library( navigation_server
+    src/navigation_goal_manager.cpp
+    src/navigator.cpp
+)
+add_dependencies(navigation_server ${catkin_EXPORTED_TARGETS})
+
+add_library( navigation_client 
+    src/navigation_client.cpp
+)
+add_dependencies(navigation_client ${catkin_EXPORTED_TARGETS})
+
 
 add_executable(navigation_action_server 
     src/navigation_action_server.cpp
-    src/navigator.cpp
 )
-target_link_libraries(navigation_action_server ${catkin_LIBRARIES} navigation_goal_manager)
 add_dependencies(navigation_action_server ${catkin_EXPORTED_TARGETS})
+target_link_libraries(navigation_action_server navigation_server ${catkin_LIBRARIES})
+
 
 add_executable(navigation_action_client 
     src/navigation_action_client.cpp
-    src/navigation_client.cpp
 )
-target_link_libraries(navigation_action_client ${catkin_LIBRARIES})
 add_dependencies(navigation_action_client ${catkin_EXPORTED_TARGETS})
+target_link_libraries(navigation_action_client navigation_client ${catkin_LIBRARIES})
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 if (CATKIN_ENABLE_TESTING)
     catkin_add_gtest(${PROJECT_NAME}-test test/test_goal_setting.cpp)
-    target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES} navigation_goal_manager)
+    target_link_libraries(${PROJECT_NAME}-test navigation_server ${catkin_LIBRARIES})
 endif()
 
 

--- a/src/tfr_navigation/CMakeLists.txt
+++ b/src/tfr_navigation/CMakeLists.txt
@@ -1,39 +1,33 @@
-# If you're having trouble getting your things to build, visit the ROS
-# tutorials at <http://wiki.ros.org/ROS/Tutorials> and also read the ROS
-# CMake documentation at <http://wiki.ros.org/catkin/CMakeLists.txt>.
-
 cmake_minimum_required(VERSION 2.8.3)
 project(tfr_navigation)
 
 add_compile_options(-std=c++11)
 
-find_package(
-    catkin REQUIRED COMPONENTS
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  tfr_msgs
+  actionlib
 )
 
 find_package(GTest REQUIRED)
 
-# These are all for exporting to dependent packages/projects.
-# Uncomment each if the dependent project requires it
 catkin_package(
-#  INCLUDE_DIRS include
-#  LIBRARIES tfr_sensor
-#  CATKIN_DEPENDS roscpp std_msgs
-#  DEPENDS system_lib
 )
 
-# Specify additional locations of header files
-# Your package locations should be listed before other locations
 include_directories(
-  include/${PROJECT_NAME}
   ${catkin_INCLUDE_DIRS}
   ${GTEST_INCLUDE_DIRS}
 )
 
-# This call is sometimes needed and sometimes not and I'm not really clear why
+
+
+
+add_executable(navigation_action_server src/navigation_action_server.cpp)
+target_link_libraries(navigation_action_server ${catkin_LIBRARIES})
+add_dependencies(navigation_action_server ${catkin_EXPORTED_TARGETS})
+
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
-# Add gtest based cpp test target and link libraries
 if(TARGET ${PROJECT_NAME}-test)
   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}_library)
 endif()

--- a/src/tfr_navigation/CMakeLists.txt
+++ b/src/tfr_navigation/CMakeLists.txt
@@ -20,12 +20,7 @@ include_directories(
 )
 
 catkin_package(
-    INCLUDE_DIRS include/${PROJECT_NAME}
-    LIBRARIES ${PROJECT_NAME} navigation_server navigation_client
-    CATKIN_DEPENDS  roscpp tfr_msgs actionlib nav_msgs geometry_msgs
 )
-
-
 
 
 add_library( navigation_server
@@ -45,7 +40,6 @@ add_executable(navigation_action_server
 )
 add_dependencies(navigation_action_server ${catkin_EXPORTED_TARGETS})
 target_link_libraries(navigation_action_server navigation_server ${catkin_LIBRARIES})
-
 
 add_executable(navigation_action_client 
     src/navigation_action_client.cpp

--- a/src/tfr_navigation/CMakeLists.txt
+++ b/src/tfr_navigation/CMakeLists.txt
@@ -6,6 +6,9 @@ add_compile_options(-std=c++11)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   tfr_msgs
+  geometry_msgs
+  nav_msgs
+  std_msgs
   actionlib
 )
 
@@ -15,23 +18,34 @@ catkin_package(
 )
 
 include_directories(
-  ${catkin_INCLUDE_DIRS}
-  ${GTEST_INCLUDE_DIRS}
+    include/${PROJECT_NAME}
+    ${catkin_INCLUDE_DIRS}
+    ${GTEST_INCLUDE_DIRS}
 )
 
+add_library(navigation_goal_manager src/navigation_goal_manager.cpp)
+target_link_libraries(navigation_goal_manager ${catkin_LIBRARIES}) 
 
-
-
-add_executable(navigation_action_server src/navigation_action_server.cpp)
-target_link_libraries(navigation_action_server ${catkin_LIBRARIES})
+add_executable(navigation_action_server 
+    src/navigation_action_server.cpp
+    src/navigator.cpp
+)
+target_link_libraries(navigation_action_server ${catkin_LIBRARIES} navigation_goal_manager)
 add_dependencies(navigation_action_server ${catkin_EXPORTED_TARGETS})
 
-add_executable(navigation_action_client src/navigation_action_client.cpp)
+add_executable(navigation_action_client 
+    src/navigation_action_client.cpp
+    src/navigation_client.cpp
+)
 target_link_libraries(navigation_action_client ${catkin_LIBRARIES})
 add_dependencies(navigation_action_client ${catkin_EXPORTED_TARGETS})
 
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
-if(TARGET ${PROJECT_NAME}-test)
-  target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME}_library)
+if (CATKIN_ENABLE_TESTING)
+    catkin_add_gtest(${PROJECT_NAME}-test test/test_goal_setting.cpp)
+    target_link_libraries(${PROJECT_NAME}-test ${catkin_LIBRARIES} navigation_goal_manager)
 endif()
+
+
+

--- a/src/tfr_navigation/CMakeLists.txt
+++ b/src/tfr_navigation/CMakeLists.txt
@@ -26,6 +26,10 @@ add_executable(navigation_action_server src/navigation_action_server.cpp)
 target_link_libraries(navigation_action_server ${catkin_LIBRARIES})
 add_dependencies(navigation_action_server ${catkin_EXPORTED_TARGETS})
 
+add_executable(navigation_action_client src/navigation_action_client.cpp)
+target_link_libraries(navigation_action_client ${catkin_LIBRARIES})
+add_dependencies(navigation_action_client ${catkin_EXPORTED_TARGETS})
+
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 if(TARGET ${PROJECT_NAME}-test)

--- a/src/tfr_navigation/include/tfr_navigation/navigation_client.h
+++ b/src/tfr_navigation/include/tfr_navigation/navigation_client.h
@@ -1,0 +1,40 @@
+/**
+ *  Test Class for the navigation action server, eventuall will be enveloped
+ *  into the executive node. 
+ *
+ *  Attaches to the node named "navigation_action_server" in the global
+ *  namespace.
+ *
+ *  Subscribes to all of the usual topics needed by a simple action client
+ *
+ * */
+#ifndef NAVIGATION_CLIENT_H
+#define NAVIGATION_CLIENT_H
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <actionlib/client/simple_action_client.h>
+#include <boost/bind.hpp>
+#include <cstdint>
+#include <tfr_msgs/NavigationAction.h>
+class NavigationClient
+{
+    public:
+        NavigationClient(std::string action_name);
+        ~NavigationClient() {} 
+
+        //delete generated methods
+        NavigationClient(const NavigationClient&) = delete;
+        NavigationClient& operator=(const NavigationClient&) = delete;
+        NavigationClient(NavigationClient&&) = delete;
+        NavigationClient& operator=(NavigationClient&&) = delete;
+        void navigate_to_mining();
+
+    private:
+        void navigate(uint8_t action);
+        void feedback(const tfr_msgs::NavigationFeedbackConstPtr& feedback);
+        void finished(const actionlib::SimpleClientGoalState &state, 
+                const tfr_msgs::NavigationResultConstPtr &result);
+        using Client = actionlib::SimpleActionClient<tfr_msgs::NavigationAction>; 
+        Client client;
+};
+#endif

--- a/src/tfr_navigation/include/tfr_navigation/navigation_client.h
+++ b/src/tfr_navigation/include/tfr_navigation/navigation_client.h
@@ -19,6 +19,11 @@
 class NavigationClient
 {
     public:
+        enum class Location : uint8_t 
+        {
+            MINING = tfr_msgs::NavigationGoal::TO_MINING,
+            DUMPING = tfr_msgs::NavigationGoal::TO_DUMPING
+        };
         NavigationClient(std::string action_name);
         ~NavigationClient() {} 
 
@@ -27,10 +32,13 @@ class NavigationClient
         NavigationClient& operator=(const NavigationClient&) = delete;
         NavigationClient(NavigationClient&&) = delete;
         NavigationClient& operator=(NavigationClient&&) = delete;
-        void navigate_to_mining();
+
+        //basic utilities
+        void navigate(uint8_t location);
+        void stop_all();
+        actionlib::SimpleClientGoalState get_state();
 
     private:
-        void navigate(uint8_t action);
         void feedback(const tfr_msgs::NavigationFeedbackConstPtr& feedback);
         void finished(const actionlib::SimpleClientGoalState &state, 
                 const tfr_msgs::NavigationResultConstPtr &result);

--- a/src/tfr_navigation/include/tfr_navigation/navigation_goal_manager.h
+++ b/src/tfr_navigation/include/tfr_navigation/navigation_goal_manager.h
@@ -10,25 +10,60 @@
 class NavigationGoalManager
 {
     public:
-        //dist_landing + dist_obstacle + 1/2 robot_length
-        constexpr static double SAFE_MINING_DISTANCE { 1.5 + 2.98 + 1.3/2 };
-        //mining_zone_width - digging_radius
-        constexpr static double MINING_LINE_LENGTH { 3.78 - 1.75 };
-        //length of landing zone
-        constexpr static double FINISH_LINE { 1.5 };
+        /* 
+         * Immutable struct of geometry constraints for the goal selection
+         * algorithm
+         * */
+        struct GeometryConstraints 
+        {
+            public:
+                GeometryConstraints(double d, double l, double f) :
+                    safe_mining_distance{d}, mining_line_length{l},
+                    finish_line{f}{};
 
-        NavigationGoalManager();
-        NavigationGoalManager(uint8_t code);
+                double get_safe_mining_distance() const
+                {
+                    return safe_mining_distance;
+                }
+
+                double get_mining_line_length() const
+                {
+                    return mining_line_length;
+                }
+
+                double get_finish_line() const
+                {
+                    return finish_line;
+                }
+            private:
+                //The distance to travel from the bin
+                double safe_mining_distance;
+                //The length of the varying mining line
+                double mining_line_length;
+                //the distance from the bin the finish line is
+                double finish_line;
+
+        };
+
+
+        NavigationGoalManager(const GeometryConstraints &constraints);
+        NavigationGoalManager(const GeometryConstraints &constraints, uint8_t code);
         NavigationGoalManager(const NavigationGoalManager&) = delete;
         NavigationGoalManager& operator=(const NavigationGoalManager&) = delete;
         NavigationGoalManager(NavigationGoalManager&&) = delete;
         NavigationGoalManager& operator=(NavigationGoalManager&&) = delete;
 
-        void initialize_goal();
-        void update_mining_goal(geometry_msgs::Pose msg);
+        move_base_msgs::MoveBaseGoal initialize_goal();
+        move_base_msgs::MoveBaseGoal get_updated_mining_goal(
+                geometry_msgs::Pose msg);
 
         //delegate initialization to ctor
         uint8_t location_code;
+
+        //the constraints to the problem
+        const GeometryConstraints &constraints;
+    private:
+        //the navigation goal
         move_base_msgs::MoveBaseGoal nav_goal{};
 };
 #endif

--- a/src/tfr_navigation/include/tfr_navigation/navigation_goal_manager.h
+++ b/src/tfr_navigation/include/tfr_navigation/navigation_goal_manager.h
@@ -1,0 +1,34 @@
+#ifndef NAVIGATION_GOAL_MANAGER_H
+#define NAVIGATION_GOAL_MANAGER_H
+#include <ros/console.h>
+#include <ros/ros.h>
+#include <geometry_msgs/Pose.h>
+#include <move_base_msgs/MoveBaseAction.h>
+#include <tfr_msgs/NavigationAction.h>
+#include <cstdint>
+#include <cmath>
+class NavigationGoalManager
+{
+    public:
+        //dist_landing + dist_obstacle + 1/2 robot_length
+        constexpr static double SAFE_MINING_DISTANCE { 1.5 + 2.98 + 1.3/2 };
+        //mining_zone_width - digging_radius
+        constexpr static double MINING_LINE_LENGTH { 3.78 - 1.75 };
+        //length of landing zone
+        constexpr static double FINISH_LINE { 1.5 };
+
+        NavigationGoalManager();
+        NavigationGoalManager(uint8_t code);
+        NavigationGoalManager(const NavigationGoalManager&) = delete;
+        NavigationGoalManager& operator=(const NavigationGoalManager&) = delete;
+        NavigationGoalManager(NavigationGoalManager&&) = delete;
+        NavigationGoalManager& operator=(NavigationGoalManager&&) = delete;
+
+        void initialize_goal();
+        void update_mining_goal(geometry_msgs::Pose msg);
+
+        //delegate initialization to ctor
+        uint8_t location_code;
+        move_base_msgs::MoveBaseGoal nav_goal{};
+};
+#endif

--- a/src/tfr_navigation/include/tfr_navigation/navigator.h
+++ b/src/tfr_navigation/include/tfr_navigation/navigator.h
@@ -1,0 +1,52 @@
+/**
+ *  Controls the business logic of the navigation subsystem. 
+ *  Mainly it accepts commands to go to specific locations, and manages the 
+ *  goal of the navigation stack at a set interval to get it there.
+ *
+ *  Publishes and subscribes to the standard topics for a navigation action
+ *  server.
+ *
+ *  Relevant Messages: Navigation[Goal|Feedback|Result]
+ * */
+#ifndef NAVIGATOR_H
+#define NAVIGATOR_H
+#include<ros/ros.h>
+#include<ros/console.h>
+#include<actionlib/server/simple_action_server.h>
+#include<navigation_goal_manager.h>
+#include<tfr_msgs/NavigationAction.h>
+#include<nav_msgs/Odometry.h>
+#include<boost/bind.hpp>
+#include<cstdint>
+class Navigator
+{ 
+    public:
+        Navigator(ros::NodeHandle& n, std::string name);
+    private:
+        void navigate(const tfr_msgs::NavigationGoalConstPtr &goal);
+
+        void update_position(const nav_msgs::OdometryConstPtr &msg);
+
+       using Server = actionlib::SimpleActionServer<tfr_msgs::NavigationAction>; 
+
+       ros::NodeHandle& node;
+
+       //NOTE delegate initialization of server to ctor
+       Server server;                      //handle to as
+       //NOTE delegate initialization of subscriber to ctor
+       ros::Subscriber odom_subscriber;    
+       //NOTE delegate initialization of mgr to ctor
+       NavigationGoalManager goal_manager;
+
+       //needed msgs
+       tfr_msgs::NavigationFeedback feedback{};
+       tfr_msgs::NavigationResult result{};
+       nav_msgs::OdometryConstPtr current_position{};
+
+       //parameters
+       std::string frame_id{};
+       std::string action_name{};
+       std::string odometry_topic{};
+       float rate{};
+};
+#endif

--- a/src/tfr_navigation/include/tfr_navigation/navigator.h
+++ b/src/tfr_navigation/include/tfr_navigation/navigator.h
@@ -22,6 +22,12 @@ class Navigator
 { 
     public:
         Navigator(ros::NodeHandle& n, std::string name);
+        ~Navigator(){}
+        Navigator(const Navigator&) = delete;
+        Navigator& operator=(const Navigator&) = delete;
+        Navigator(Navigator&&) = delete;
+        Navigator& operator=(Navigator&&) = delete;
+
     private:
         void navigate(const tfr_msgs::NavigationGoalConstPtr &goal);
 
@@ -41,7 +47,7 @@ class Navigator
        //needed msgs
        tfr_msgs::NavigationFeedback feedback{};
        tfr_msgs::NavigationResult result{};
-       nav_msgs::OdometryConstPtr current_position{};
+       nav_msgs::Odometry current_position{};
 
        //parameters
        std::string frame_id{};

--- a/src/tfr_navigation/include/tfr_navigation/navigator.h
+++ b/src/tfr_navigation/include/tfr_navigation/navigator.h
@@ -10,18 +10,20 @@
  * */
 #ifndef NAVIGATOR_H
 #define NAVIGATOR_H
-#include<ros/ros.h>
-#include<ros/console.h>
-#include<actionlib/server/simple_action_server.h>
-#include<navigation_goal_manager.h>
-#include<tfr_msgs/NavigationAction.h>
-#include<nav_msgs/Odometry.h>
-#include<boost/bind.hpp>
-#include<cstdint>
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <actionlib/server/simple_action_server.h>
+#include <navigation_goal_manager.h>
+#include <tfr_msgs/NavigationAction.h>
+#include <nav_msgs/Odometry.h>
+#include <boost/bind.hpp>
+#include <cstdint>
 class Navigator
 { 
     public:
-        Navigator(ros::NodeHandle& n, std::string name);
+        Navigator(ros::NodeHandle& n,
+                const NavigationGoalManager::GeometryConstraints &constraints,
+                std::string name);
         ~Navigator(){}
         Navigator(const Navigator&) = delete;
         Navigator& operator=(const Navigator&) = delete;
@@ -33,26 +35,28 @@ class Navigator
 
         void update_position(const nav_msgs::OdometryConstPtr &msg);
 
-       using Server = actionlib::SimpleActionServer<tfr_msgs::NavigationAction>; 
+        using Server = actionlib::SimpleActionServer<tfr_msgs::NavigationAction>; 
 
-       ros::NodeHandle& node;
+        ros::NodeHandle& node;
 
-       //NOTE delegate initialization of server to ctor
-       Server server;                      //handle to as
-       //NOTE delegate initialization of subscriber to ctor
-       ros::Subscriber odom_subscriber;    
-       //NOTE delegate initialization of mgr to ctor
-       NavigationGoalManager goal_manager;
+        //NOTE delegate initialization of server to ctor
+        Server server;                      //handle to as
+        //NOTE delegate initialization of subscriber to ctor
+        ros::Subscriber odom_subscriber;    
+        //NOTE delegate initialization of mgr to ctor
+        NavigationGoalManager goal_manager;
 
-       //needed msgs
-       tfr_msgs::NavigationFeedback feedback{};
-       tfr_msgs::NavigationResult result{};
-       nav_msgs::Odometry current_position{};
+        //needed msgs
+        tfr_msgs::NavigationFeedback feedback{};
+        tfr_msgs::NavigationResult result{};
+        nav_msgs::Odometry current_position{};
+        move_base_msgs::MoveBaseGoal nav_goal{};
 
-       //parameters
-       std::string frame_id{};
-       std::string action_name{};
-       std::string odometry_topic{};
-       float rate{};
+        //parameters
+        std::string frame_id{};
+        std::string action_name{};
+        std::string odometry_topic{};
+
+        float rate{};
 };
 #endif

--- a/src/tfr_navigation/launch/action_client.launch
+++ b/src/tfr_navigation/launch/action_client.launch
@@ -1,0 +1,5 @@
+<launch>
+    <node name="navigation_action_client" pkg="tfr_navigation" type="navigation_action_client"
+        output="screen">
+    </node>
+</launch>

--- a/src/tfr_navigation/launch/action_server.launch
+++ b/src/tfr_navigation/launch/action_server.launch
@@ -1,0 +1,5 @@
+<launch>
+    <node name="navigation_action_server" pkg="tfr_navigation" type="navigation_action_server"
+        output="screen">
+    </node>
+</launch>

--- a/src/tfr_navigation/package.xml
+++ b/src/tfr_navigation/package.xml
@@ -14,9 +14,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <test_depend>gtest</test_depend>
-
   <depend>roscpp</depend>
   <depend>tfr_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>geometry_msgs</depend>
   <depend>actionlib</depend>
->>>>>>> added bare action server
+
 </package>

--- a/src/tfr_navigation/package.xml
+++ b/src/tfr_navigation/package.xml
@@ -14,8 +14,9 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <test_depend>gtest</test_depend>
-  <depend>rtabmap_ros</depend>
-  <depend>rtabmap</depend>
-  <depend>roscpp</depend>
 
+  <depend>roscpp</depend>
+  <depend>tfr_msgs</depend>
+  <depend>actionlib</depend>
+>>>>>>> added bare action server
 </package>

--- a/src/tfr_navigation/src/navigation_action_client.cpp
+++ b/src/tfr_navigation/src/navigation_action_client.cpp
@@ -1,91 +1,15 @@
+#include<ros/ros.h>
+#include<navigation_client.h>
 /**
- *  Test Class for the navigation action server, eventuall will be enveloped
- *  into the executive node. 
- *
- *  Attaches to the node named "navigation_action_server" in the global
- *  namespace.
- *
- *  Subscribes to all of the usual topics needed by a simple action client
- *
+ *  Main entry point for test class of navigation action server, eventually
+ *  these helper objects will be transferred to the exective action server
+ *  TODO
  * */
-#include <ros/ros.h>
-#include <ros/console.h>
-#include <cstdint>
-#include <tfr_msgs/NavigationAction.h>
-#include <actionlib/client/simple_action_client.h>
-
-
-class NavigationClient
-{
-    public:
-        NavigationClient(std::string action_name):client{action_name, true}
-        {
-            client.waitForServer();
-        }
-
-        ~NavigationClient() {} 
-        //delete generated methods
-        NavigationClient(const NavigationClient&) = delete;
-        NavigationClient& operator=(const NavigationClient&) = delete;
-        NavigationClient(NavigationClient&&) = delete;
-        NavigationClient& operator=(NavigationClient&&) = delete;
-        
-        /**
-         * Signals the server to drop whatever it may be doing and navigate to
-         * the mining zone.
-         */
-        void navigate_to_mining()
-        {
-            //lets navigate to the mining zone!
-            navigate(tfr_msgs::NavigationGoal::TO_MINING);
-        }
-
-    private:
-        /**
-         * Navigate to an arbirtrary defined place as defined in the Navigation
-         * Goal constants header.
-         *
-         * action - The byte code corresponding to a location in the world map
-         * */
-        void navigate(uint8_t action)
-        {
-            tfr_msgs::NavigationGoal goal;
-            goal.cmd_code = action;
-            client.sendGoal(goal,
-                    boost::bind(&NavigationClient::finished,this, _1,_2),
-                    Client::SimpleActiveCallback(),
-                    boost::bind(&NavigationClient::feedback,this, _1));
-        }
-
-
-        /**
-         *  Standard feedback callback for action client.
-         * */
-        void feedback(const tfr_msgs::NavigationFeedbackConstPtr& feedback)
-        {
-            ROS_INFO("feedback recieved, code: %d", feedback->status);
-        }
-
-        /**
-         * Standard finishing callback for action client. 
-         * */
-        void finished(const actionlib::SimpleClientGoalState &state, const
-                tfr_msgs::NavigationResultConstPtr &result)
-        {
-            ROS_INFO("result recieved, code: %d", result->status);
-            ros::shutdown();
-        }
-        using Client = actionlib::SimpleActionClient<tfr_msgs::NavigationAction>; 
-        
-
-        //the action client
-        Client client;
-};
-
 int main(int argc, char** argv)
 {
     ros::init(argc, argv, "navigation_action_client");
     ros::NodeHandle n;
+
     NavigationClient client("navigation_action_server");
     client.navigate_to_mining();
 

--- a/src/tfr_navigation/src/navigation_action_client.cpp
+++ b/src/tfr_navigation/src/navigation_action_client.cpp
@@ -1,0 +1,94 @@
+/**
+ *  Test Class for the navigation action server, eventuall will be enveloped
+ *  into the executive node. 
+ *
+ *  Attaches to the node named "navigation_action_server" in the global
+ *  namespace.
+ *
+ *  Subscribes to all of the usual topics needed by a simple action client
+ *
+ * */
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <cstdint>
+#include <tfr_msgs/NavigationAction.h>
+#include <actionlib/client/simple_action_client.h>
+
+
+class NavigationClient
+{
+    public:
+        NavigationClient(std::string action_name):client{action_name, true}
+        {
+            client.waitForServer();
+        }
+
+        ~NavigationClient() {} 
+        //delete generated methods
+        NavigationClient(const NavigationClient&) = delete;
+        NavigationClient& operator=(const NavigationClient&) = delete;
+        NavigationClient(NavigationClient&&) = delete;
+        NavigationClient& operator=(NavigationClient&&) = delete;
+        
+        /**
+         * Signals the server to drop whatever it may be doing and navigate to
+         * the mining zone.
+         */
+        void navigate_to_mining()
+        {
+            //lets navigate to the mining zone!
+            navigate(tfr_msgs::NavigationGoal::TO_MINING);
+        }
+
+    private:
+        /**
+         * Navigate to an arbirtrary defined place as defined in the Navigation
+         * Goal constants header.
+         *
+         * action - The byte code corresponding to a location in the world map
+         * */
+        void navigate(uint8_t action)
+        {
+            tfr_msgs::NavigationGoal goal;
+            goal.cmd_code = action;
+            client.sendGoal(goal,
+                    boost::bind(&NavigationClient::finished,this, _1,_2),
+                    Client::SimpleActiveCallback(),
+                    boost::bind(&NavigationClient::feedback,this, _1));
+        }
+
+
+        /**
+         *  Standard feedback callback for action client.
+         * */
+        void feedback(const tfr_msgs::NavigationFeedbackConstPtr& feedback)
+        {
+            ROS_INFO("feedback recieved, code: %d", feedback->status);
+        }
+
+        /**
+         * Standard finishing callback for action client. 
+         * */
+        void finished(const actionlib::SimpleClientGoalState &state, const
+                tfr_msgs::NavigationResultConstPtr &result)
+        {
+            ROS_INFO("result recieved, code: %d", result->status);
+            ros::shutdown();
+        }
+        using Client = actionlib::SimpleActionClient<tfr_msgs::NavigationAction>; 
+        
+
+        //the action client
+        Client client;
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "navigation_action_client");
+    ros::NodeHandle n;
+    NavigationClient client("navigation_action_server");
+    client.navigate_to_mining();
+
+    ros::spin();
+    return 0;
+}

--- a/src/tfr_navigation/src/navigation_action_client.cpp
+++ b/src/tfr_navigation/src/navigation_action_client.cpp
@@ -1,5 +1,7 @@
 #include<ros/ros.h>
 #include<navigation_client.h>
+#include<tfr_msgs/NavigationAction.h>
+
 /**
  *  Main entry point for test class of navigation action server, eventually
  *  these helper objects will be transferred to the exective action server
@@ -11,8 +13,21 @@ int main(int argc, char** argv)
     ros::NodeHandle n;
 
     NavigationClient client("navigation_action_server");
-    client.navigate_to_mining();
+    //test preemption
+    client.navigate(tfr_msgs::NavigationGoal::TO_MINING);
+    client.stop_all();
+    
+    //test happy path mining
+    client.navigate(tfr_msgs::NavigationGoal::TO_MINING);
+    for (int i = 0; i < 16; i++)
+    {
+        ros::spinOnce();
+        ros::Duration(0.25).sleep();
+    }
 
+    
+    //test happy path dumping
+    client.navigate(tfr_msgs::NavigationGoal::TO_DUMPING);
     ros::spin();
     return 0;
 }

--- a/src/tfr_navigation/src/navigation_action_server.cpp
+++ b/src/tfr_navigation/src/navigation_action_server.cpp
@@ -1,0 +1,40 @@
+#include <actionlib/server/simple_action_server.h>
+#include <tfr_msgs/NavigationAction.h>  
+#include <ros/console.h>
+#include <ros/ros.h>
+
+using Server = actionlib::SimpleActionServer<tfr_msgs::NavigationAction>;
+
+class Navigator
+{ 
+    public:
+        Navigator(std::string name): action_name{name}, n{}, s{n, action_name,
+            boost::bind(&Navigator::navigate, this, _1), false}
+        {
+            s.start();
+        }
+
+        
+
+        void navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
+        {
+            //do the action here
+            ROS_INFO("NavigationAction");
+            s.publishFeedback(feedback);
+            s.setSucceeded(result);
+        }
+
+    private:
+        std::string action_name;
+        ros::NodeHandle n;
+        Server s;
+        tfr_msgs::NavigationFeedback feedback;
+        tfr_msgs::NavigationResult result;
+
+};
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "navigation_action_server");
+    Navigator("navigate");
+}

--- a/src/tfr_navigation/src/navigation_action_server.cpp
+++ b/src/tfr_navigation/src/navigation_action_server.cpp
@@ -1,40 +1,83 @@
+/**
+ *  Entry point and node of the navigation action server, controls the business
+ *  logic of the navigation subsystem.
+ *
+ *  Publishes and subscribes to the standard topics for a navigation action
+ *  server.
+ *
+ *  Relevant Messages: Navigation[Goal|Feedback|Result]
+ * */
 #include <actionlib/server/simple_action_server.h>
 #include <tfr_msgs/NavigationAction.h>  
 #include <ros/console.h>
 #include <ros/ros.h>
 
-using Server = actionlib::SimpleActionServer<tfr_msgs::NavigationAction>;
-
+/**
+ *  The action server, it's public interface for it's action is as follows:
+ *
+ *  Goal: 
+ *      -uint8_t code corresponding to where we want to navigate. Goal list is
+ *      described in Navigation.action in the tfr_msgs package
+ *  Feedback:
+ *      -uint8_t code corresponding to our current status described in 
+ *      Navigation.action in the tfr_msgs package
+ *      -Pose describing the current position
+ *      -Pose describing the final targeted position
+ *  Response
+ *      -uint8_t code corresponding to the finsal status described in 
+ *      Navigation.action in the tfr_msgs package
+ *      -Pose describing our final position
+ * */
 class Navigator
 { 
-    public:
-        Navigator(std::string name): action_name{name}, n{}, s{n, action_name,
-            boost::bind(&Navigator::navigate, this, _1), false}
-        {
-            s.start();
-        }
 
-        
+    public:
+        /**
+         *  constructs the sever and binds it to it's execution callback
+         * */
+        Navigator(std::string name) :  server{n, name,
+            boost::bind(&Navigator::navigate, this, _1) ,false}, action_name{name}
+        {
+            ROS_INFO("Navigation server constructed");
+            server.start();
+            ROS_INFO("Navigation server awaiting connection");
+        }
 
         void navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
         {
             //do the action here
-            ROS_INFO("NavigationAction");
-            s.publishFeedback(feedback);
-            s.setSucceeded(result);
+            ROS_INFO("Navigation server started");
+            if (server.isPreemptRequested() || !ros::ok()) 
+            {
+                ROS_INFO("%s: preempted", action_name.c_str());
+                server.setPreempted();
+            }
+            else
+            {
+                feedback.status = tfr_msgs::NavigationFeedback::OK;
+                server.publishFeedback(feedback);
+                tfr_msgs::NavigationResult result;
+                result.status = tfr_msgs::NavigationResult::OK;
+                server.setSucceeded(result);
+                ROS_INFO("Navigation server finished");
+            }
         }
 
     private:
-        std::string action_name;
-        ros::NodeHandle n;
-        Server s;
+        using Server = actionlib::SimpleActionServer<tfr_msgs::NavigationAction>; 
+        ros::NodeHandle n; // the node for the server
+        Server server;
         tfr_msgs::NavigationFeedback feedback;
-        tfr_msgs::NavigationResult result;
+        std::string action_name;
 
 };
 
 int main(int argc, char** argv)
 {
+    
     ros::init(argc, argv, "navigation_action_server");
-    Navigator("navigate");
+    Navigator navigator(ros::this_node::getName());
+    ros::spin();
+    return 0;
 }
+

--- a/src/tfr_navigation/src/navigation_action_server.cpp
+++ b/src/tfr_navigation/src/navigation_action_server.cpp
@@ -8,7 +8,15 @@ int main(int argc, char** argv)
 {
     ros::init(argc, argv, "navigation_action_server");
     ros::NodeHandle n;
-    Navigator navigator(n, ros::this_node::getName());
+    double safe_mining_distance, mining_line_length, finish_line;
+
+    ros::param::param<double>("~safe_mining_distance", safe_mining_distance, 5.1);
+    ros::param::param<double>("~mining_line_length", mining_line_length, 2.03);
+    ros::param::param<double>("~finish_line", finish_line, 0.84);
+    
+    NavigationGoalManager::GeometryConstraints 
+        constraints(safe_mining_distance, mining_line_length, finish_line);
+    Navigator navigator(n, constraints, ros::this_node::getName());
     ros::spin();
     return 0;
 }

--- a/src/tfr_navigation/src/navigation_action_server.cpp
+++ b/src/tfr_navigation/src/navigation_action_server.cpp
@@ -1,82 +1,14 @@
+#include<ros/ros.h>
+#include<navigator.h>
 /**
- *  Entry point and node of the navigation action server, controls the business
- *  logic of the navigation subsystem.
- *
- *  Publishes and subscribes to the standard topics for a navigation action
- *  server.
- *
- *  Relevant Messages: Navigation[Goal|Feedback|Result]
+ * Main entry point for the navigation action server, spins up the server and
+ * awaits callbacks.
  * */
-#include <actionlib/server/simple_action_server.h>
-#include <tfr_msgs/NavigationAction.h>  
-#include <ros/console.h>
-#include <ros/ros.h>
-
-/**
- *  The action server, it's public interface for it's action is as follows:
- *
- *  Goal: 
- *      -uint8_t code corresponding to where we want to navigate. Goal list is
- *      described in Navigation.action in the tfr_msgs package
- *  Feedback:
- *      -uint8_t code corresponding to our current status described in 
- *      Navigation.action in the tfr_msgs package
- *      -Pose describing the current position
- *      -Pose describing the final targeted position
- *  Response
- *      -uint8_t code corresponding to the finsal status described in 
- *      Navigation.action in the tfr_msgs package
- *      -Pose describing our final position
- * */
-class Navigator
-{ 
-
-    public:
-        /**
-         *  constructs the sever and binds it to it's execution callback
-         * */
-        Navigator(std::string name) :  server{n, name,
-            boost::bind(&Navigator::navigate, this, _1) ,false}, action_name{name}
-        {
-            ROS_INFO("Navigation server constructed");
-            server.start();
-            ROS_INFO("Navigation server awaiting connection");
-        }
-
-        void navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
-        {
-            //do the action here
-            ROS_INFO("Navigation server started");
-            if (server.isPreemptRequested() || !ros::ok()) 
-            {
-                ROS_INFO("%s: preempted", action_name.c_str());
-                server.setPreempted();
-            }
-            else
-            {
-                feedback.status = tfr_msgs::NavigationFeedback::OK;
-                server.publishFeedback(feedback);
-                tfr_msgs::NavigationResult result;
-                result.status = tfr_msgs::NavigationResult::OK;
-                server.setSucceeded(result);
-                ROS_INFO("Navigation server finished");
-            }
-        }
-
-    private:
-        using Server = actionlib::SimpleActionServer<tfr_msgs::NavigationAction>; 
-        ros::NodeHandle n; // the node for the server
-        Server server;
-        tfr_msgs::NavigationFeedback feedback;
-        std::string action_name;
-
-};
-
 int main(int argc, char** argv)
 {
-    
     ros::init(argc, argv, "navigation_action_server");
-    Navigator navigator(ros::this_node::getName());
+    ros::NodeHandle n;
+    Navigator navigator(n, ros::this_node::getName());
     ros::spin();
     return 0;
 }

--- a/src/tfr_navigation/src/navigation_client.cpp
+++ b/src/tfr_navigation/src/navigation_client.cpp
@@ -19,6 +19,13 @@ void NavigationClient::navigate(uint8_t location)
 {
     tfr_msgs::NavigationGoal goal;
     goal.location_code= location;
+
+
+    /*Maintenece Note:
+     *  The SimpleActiveCallback() method below doesn't do anything, it's a
+     *  placeholder provided by the library maintainers to pass into the method
+     *  if you don't have a relevant callback to pass in.
+     * */
     client.sendGoal(goal,
             boost::bind(&NavigationClient::finished,this, _1,_2),
             Client::SimpleActiveCallback(),

--- a/src/tfr_navigation/src/navigation_client.cpp
+++ b/src/tfr_navigation/src/navigation_client.cpp
@@ -7,32 +7,42 @@ NavigationClient::NavigationClient(std::string action_name):client{action_name, 
 {
     client.waitForServer();
 }
-       
-/**
- * Signals the server to drop whatever it may be doing and navigate to
- * the mining zone.
- */
-void NavigationClient::navigate_to_mining()
-{
-    //lets navigate to the mining zone!
-    navigate(tfr_msgs::NavigationGoal::TO_MINING);
-}
+
 
 /**
- * Navigate to an arbirtrary defined place as defined in the Navigation
+ * Nonblocking call to Navigate to an arbirtrary defined place as defined in the Navigation
  * Goal constants header.
  *
  * action - The byte code corresponding to a location in the world map
  * */
-void NavigationClient::navigate(uint8_t action)
+void NavigationClient::navigate(uint8_t location)
 {
     tfr_msgs::NavigationGoal goal;
-    goal.location_code= action;
+    goal.location_code= location;
     client.sendGoal(goal,
             boost::bind(&NavigationClient::finished,this, _1,_2),
             Client::SimpleActiveCallback(),
             boost::bind(&NavigationClient::feedback,this, _1));
 }
+
+/**
+ * Stops all goals on the navigation action server
+ * */
+void NavigationClient::stop_all()
+{
+    client.cancelAllGoals();
+}
+
+/**
+ * Nonblocking gets the state of the action server
+ * */
+actionlib::SimpleClientGoalState NavigationClient::get_state()
+{
+    return client.getState();
+}
+
+
+
 
 /**
  *  Standard feedback callback for action client.
@@ -49,5 +59,4 @@ void NavigationClient::finished(const actionlib::SimpleClientGoalState &state, c
         tfr_msgs::NavigationResultConstPtr &result)
 {
     ROS_INFO("result recieved, code: %d", result->status);
-    ros::shutdown();
 }

--- a/src/tfr_navigation/src/navigation_client.cpp
+++ b/src/tfr_navigation/src/navigation_client.cpp
@@ -1,0 +1,53 @@
+#include <navigation_client.h>
+        
+/**
+ *  default constructor, brings up a server to listen to a specific action
+ * */
+NavigationClient::NavigationClient(std::string action_name):client{action_name, true}
+{
+    client.waitForServer();
+}
+       
+/**
+ * Signals the server to drop whatever it may be doing and navigate to
+ * the mining zone.
+ */
+void NavigationClient::navigate_to_mining()
+{
+    //lets navigate to the mining zone!
+    navigate(tfr_msgs::NavigationGoal::TO_MINING);
+}
+
+/**
+ * Navigate to an arbirtrary defined place as defined in the Navigation
+ * Goal constants header.
+ *
+ * action - The byte code corresponding to a location in the world map
+ * */
+void NavigationClient::navigate(uint8_t action)
+{
+    tfr_msgs::NavigationGoal goal;
+    goal.location_code= action;
+    client.sendGoal(goal,
+            boost::bind(&NavigationClient::finished,this, _1,_2),
+            Client::SimpleActiveCallback(),
+            boost::bind(&NavigationClient::feedback,this, _1));
+}
+
+/**
+ *  Standard feedback callback for action client.
+ * */
+void NavigationClient::feedback(const tfr_msgs::NavigationFeedbackConstPtr& feedback)
+{
+    ROS_INFO("feedback recieved, code: %d", feedback->status);
+}
+
+/**
+ * Standard finishing callback for action client. 
+ * */
+void NavigationClient::finished(const actionlib::SimpleClientGoalState &state, const
+        tfr_msgs::NavigationResultConstPtr &result)
+{
+    ROS_INFO("result recieved, code: %d", result->status);
+    ros::shutdown();
+}

--- a/src/tfr_navigation/src/navigation_goal_manager.cpp
+++ b/src/tfr_navigation/src/navigation_goal_manager.cpp
@@ -1,35 +1,48 @@
 #include <navigation_goal_manager.h>
 
-//c++11 is weird with constexpre and we need to define these outside of the
-//class in addition to the declaration and initialization step
-constexpr double NavigationGoalManager::SAFE_MINING_DISTANCE;
-constexpr double NavigationGoalManager::FINISH_LINE;
-constexpr double NavigationGoalManager::MINING_LINE_LENGTH;
-
-NavigationGoalManager::NavigationGoalManager(uint8_t code): location_code{code}
+NavigationGoalManager::NavigationGoalManager(const GeometryConstraints &c, 
+        uint8_t code): constraints{c}, location_code{code}
 {
     initialize_goal();
+    //NOTE ros is not really big on runtime exceptions,  I'll post an annoying
+    //warning at startup
+    if (    constraints.get_safe_mining_distance() < 0 || 
+            constraints.get_mining_line_length() < 0 || 
+            constraints.get_finish_line() < 0)
+    {
+        ROS_WARN("Mining constraints should be positive %f", 
+                ros::Time::now().toSec());
+        ROS_WARN("    safe_mining_distance: %f",
+                constraints.get_safe_mining_distance());
+        ROS_WARN("    mining_line_distance: %f",
+                constraints.get_mining_line_length());
+        ROS_WARN("    finish_line: %f",
+                constraints.get_finish_line());
+    }
+    
 }
-NavigationGoalManager::NavigationGoalManager():
-    NavigationGoalManager{tfr_msgs::NavigationGoal::UNSET} {}
+
+NavigationGoalManager::NavigationGoalManager(const GeometryConstraints &c):
+    NavigationGoalManager{c, tfr_msgs::NavigationGoal::UNSET} {}
 
 
 /**
  *  Initializes the goal based on the location code, flashes a warning if it's
  *  not recognized.
  * */
-void NavigationGoalManager::initialize_goal() {
+move_base_msgs::MoveBaseGoal NavigationGoalManager::initialize_goal() {
     nav_goal.target_pose.header.stamp = ros::Time::now();
     //TODO integrate the bin reference frame here, upon completion of
     //the bin transform publisher
     switch(location_code)
     {
         case(tfr_msgs::NavigationGoal::TO_MINING):
-            nav_goal.target_pose.pose.position.x = SAFE_MINING_DISTANCE;
+            nav_goal.target_pose.pose.position.x =
+                constraints.get_safe_mining_distance();
             //TODO 
             break;
         case(tfr_msgs::NavigationGoal::TO_DUMPING):
-            nav_goal.target_pose.pose.position.x = FINISH_LINE;
+            nav_goal.target_pose.pose.position.x = constraints.get_finish_line();
             break;
         case(tfr_msgs::NavigationGoal::UNSET):
             //leave it alone
@@ -37,13 +50,14 @@ void NavigationGoalManager::initialize_goal() {
         default:
             ROS_WARN("location_code %d not recognized", location_code);
     }
+    return nav_goal;
 }
 
 /**
  * Update the mining goal to the most efficient place on the mining.
  * fails gracefully and warns the user if there is an error.
  */
-void NavigationGoalManager::update_mining_goal(geometry_msgs::Pose msg)
+move_base_msgs::MoveBaseGoal NavigationGoalManager::get_updated_mining_goal(geometry_msgs::Pose msg)
 {
     if (location_code == tfr_msgs::NavigationGoal::TO_MINING){
         nav_goal.target_pose.header.stamp =ros::Time::now();
@@ -51,11 +65,13 @@ void NavigationGoalManager::update_mining_goal(geometry_msgs::Pose msg)
         double v_position = msg.position.y; 
         int sign = (v_position > 0) ? 1 : -1;
         nav_goal.target_pose.pose.position.y = sign*std::min(
-                MINING_LINE_LENGTH/2, std::abs(v_position));
+                constraints.get_mining_line_length()/2, std::abs(v_position));
     }
     else 
     {
         ROS_WARN("only can update mining goal, your goal: %d", location_code);
     }
+    return nav_goal;
 }
+
 

--- a/src/tfr_navigation/src/navigation_goal_manager.cpp
+++ b/src/tfr_navigation/src/navigation_goal_manager.cpp
@@ -62,10 +62,10 @@ move_base_msgs::MoveBaseGoal NavigationGoalManager::get_updated_mining_goal(geom
     if (location_code == tfr_msgs::NavigationGoal::TO_MINING){
         nav_goal.target_pose.header.stamp =ros::Time::now();
         //TODO integrate reference frame when bin tf publisher is finished
-        double v_position = msg.position.y; 
-        int sign = (v_position > 0) ? 1 : -1;
+        double y_position = msg.position.y; 
+        int sign = (y_position > 0) ? 1 : -1;
         nav_goal.target_pose.pose.position.y = sign*std::min(
-                constraints.get_mining_line_length()/2, std::abs(v_position));
+                constraints.get_mining_line_length()/2, std::abs(y_position));
     }
     else 
     {
@@ -73,5 +73,3 @@ move_base_msgs::MoveBaseGoal NavigationGoalManager::get_updated_mining_goal(geom
     }
     return nav_goal;
 }
-
-

--- a/src/tfr_navigation/src/navigation_goal_manager.cpp
+++ b/src/tfr_navigation/src/navigation_goal_manager.cpp
@@ -1,0 +1,61 @@
+#include <navigation_goal_manager.h>
+
+//c++11 is weird with constexpre and we need to define these outside of the
+//class in addition to the declaration and initialization step
+constexpr double NavigationGoalManager::SAFE_MINING_DISTANCE;
+constexpr double NavigationGoalManager::FINISH_LINE;
+constexpr double NavigationGoalManager::MINING_LINE_LENGTH;
+
+NavigationGoalManager::NavigationGoalManager(uint8_t code): location_code{code}
+{
+    initialize_goal();
+}
+NavigationGoalManager::NavigationGoalManager():
+    NavigationGoalManager{tfr_msgs::NavigationGoal::UNSET} {}
+
+
+/**
+ *  Initializes the goal based on the location code, flashes a warning if it's
+ *  not recognized.
+ * */
+void NavigationGoalManager::initialize_goal() {
+    nav_goal.target_pose.header.stamp = ros::Time::now();
+    //TODO integrate the bin reference frame here, upon completion of
+    //the bin transform publisher
+    switch(location_code)
+    {
+        case(tfr_msgs::NavigationGoal::TO_MINING):
+            nav_goal.target_pose.pose.position.x = SAFE_MINING_DISTANCE;
+            //TODO 
+            break;
+        case(tfr_msgs::NavigationGoal::TO_DUMPING):
+            nav_goal.target_pose.pose.position.x = FINISH_LINE;
+            break;
+        case(tfr_msgs::NavigationGoal::UNSET):
+            //leave it alone
+            break;
+        default:
+            ROS_WARN("location_code %d not recognized", location_code);
+    }
+}
+
+/**
+ * Update the mining goal to the most efficient place on the mining.
+ * fails gracefully and warns the user if there is an error.
+ */
+void NavigationGoalManager::update_mining_goal(geometry_msgs::Pose msg)
+{
+    if (location_code == tfr_msgs::NavigationGoal::TO_MINING){
+        nav_goal.target_pose.header.stamp =ros::Time::now();
+        //TODO integrate reference frame when bin tf publisher is finished
+        double v_position = msg.position.y; 
+        int sign = (v_position > 0) ? 1 : -1;
+        nav_goal.target_pose.pose.position.y = sign*std::min(
+                MINING_LINE_LENGTH/2, std::abs(v_position));
+    }
+    else 
+    {
+        ROS_WARN("only can update mining goal, your goal: %d", location_code);
+    }
+}
+

--- a/src/tfr_navigation/src/navigator.cpp
+++ b/src/tfr_navigation/src/navigator.cpp
@@ -1,0 +1,126 @@
+#include <navigator.h>
+
+/**
+ *  constructs the sever and binds it to it's execution callback
+ *  displays set parameters and warnings to the user
+ * */
+Navigator::Navigator(ros::NodeHandle &n,std::string name) : node{n},  server{n, name,
+    boost::bind(&Navigator::navigate, this, _1) ,false}, action_name{name},
+    goal_manager()
+{
+    ROS_INFO("Navigation server constructed");
+    //get parameters
+    node.param<std::string>("~odometry_topic", odometry_topic,
+            "/fused_odom");
+    node.param<float>("~rate", rate, 1);
+    node.param<std::string>("~frame_id", frame_id, "base_footprint");
+
+    odom_subscriber = node.subscribe(odometry_topic, 5,
+            &Navigator::update_position, this);
+
+    //display parameters to the user
+    ROS_DEBUG(" name:           %s", action_name.c_str());
+    ROS_DEBUG(" frame_id:       %s", frame_id.c_str());
+    ROS_DEBUG(" odometry_topic: %s", odometry_topic.c_str());
+    ROS_DEBUG(" rate:           %f", rate);
+
+
+    server.start();
+
+    ROS_INFO("Navigation server awaiting connection");
+}
+
+/**
+ *  Goal: 
+ *      -uint8_t code corresponding to where we want to navigate. Goal list is
+ *      described in Navigation.action in the tfr_msgs package
+ *  Feedback:
+ *      -uint8_t code corresponding to our current status described in 
+ *      Navigation.action in the tfr_msgs package
+ *      -Pose describing the current position
+ *      -Pose describing the final targeted position
+ *  Response
+ *      -uint8_t code corresponding to the finsal status described in 
+ *      Navigation.action in the tfr_msgs package
+ *      -Pose describing our final position
+ * */
+void Navigator::navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
+{
+    ROS_INFO("Navigation server started");
+
+    //start with initial goal
+    goal_manager.location_code = (*goal).location_code;
+    goal_manager.initialize_goal();
+    //TODO send goal to navigation stack 
+
+    ros::Rate r(rate);  
+
+    //test for completion
+    //TODO hook up to navigation stack here
+
+    while (true)
+    {
+        //Deal with preemption or error
+        if (server.isPreemptRequested() || !ros::ok()) 
+        {
+            //TODO hook up to navigation stack here
+            //cascade the preemption and wait
+            ROS_INFO("%s: preempted", action_name.c_str());
+            server.setPreempted();
+            break;
+        }
+        //main case, update nav goal
+        else
+        {
+            if (goal_manager.location_code == tfr_msgs::NavigationGoal::TO_MINING)
+            {
+                //grab local copy of shared ptr for safe shared memory
+                auto position = current_position;
+                goal_manager.update_mining_goal((*position).pose.pose);
+                //TODO send updated goal to navigation stack
+            }
+
+            //TODO hookup status query to navigation stack here
+
+            feedback.header.stamp = ros::Time::now();
+            feedback.header.frame_id = frame_id;
+            feedback.status = tfr_msgs::NavigationFeedback::OK;
+            auto position = current_position;
+            feedback.current = (*position).pose.pose;
+            feedback.goal = goal_manager.nav_goal.target_pose.pose;
+            server.publishFeedback(feedback);
+            r.sleep();
+        }
+    }
+
+    //TODO hook up to navigation stack here
+    //test for success
+    if (true)
+    {
+        result.header.stamp = ros::Time::now();
+        result.header.frame_id = frame_id;
+        result.status = tfr_msgs::NavigationResult::OK;
+        auto position = current_position;
+        result.current = (*position).pose.pose;
+        result.goal = goal_manager.nav_goal.target_pose.pose;
+        server.setSucceeded(result);
+    }
+    else 
+    {
+        result.status = tfr_msgs::NavigationResult::OK;
+        server.setAborted(result);
+    }
+    ROS_INFO("Navigation server finished");
+}
+
+
+/**
+ * Callback for updating the most recent position
+ * */
+void Navigator::update_position(const nav_msgs::OdometryConstPtr &msg)
+{
+    //get the pose without the covariance, not needed
+    //need to use shared pointer here for thread safety see:
+    //https://answers.ros.org/question/53234/processing-an-image-outside-the-callback-function/
+    current_position = msg;
+}

--- a/src/tfr_navigation/src/navigator.cpp
+++ b/src/tfr_navigation/src/navigator.cpp
@@ -8,12 +8,12 @@ Navigator::Navigator(ros::NodeHandle &n,std::string name) : node{n},  server{n, 
     boost::bind(&Navigator::navigate, this, _1) ,false}, action_name{name},
     goal_manager()
 {
-    ROS_INFO("Navigation server constructed");
+    ROS_DEBUG("Navigation server constructed %f", ros::Time::now().toSec());
     //get parameters
-    node.param<std::string>("~odometry_topic", odometry_topic,
+    ros::param::param<std::string>("~odometry_topic", odometry_topic,
             "/fused_odom");
-    node.param<float>("~rate", rate, 1);
-    node.param<std::string>("~frame_id", frame_id, "base_footprint");
+    ros::param::param<float>("~rate", rate, 1);
+    ros::param::param<std::string>("~frame_id", frame_id, "base_footprint");
 
     odom_subscriber = node.subscribe(odometry_topic, 5,
             &Navigator::update_position, this);
@@ -43,6 +43,7 @@ Navigator::Navigator(ros::NodeHandle &n,std::string name) : node{n},  server{n, 
  *      -uint8_t code corresponding to the finsal status described in 
  *      Navigation.action in the tfr_msgs package
  *      -Pose describing our final position
+ *  NOTE NOT THREAD SAFE
  * */
 void Navigator::navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
 {
@@ -54,10 +55,11 @@ void Navigator::navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
     //TODO send goal to navigation stack 
 
     ros::Rate r(rate);  
+    r.sleep(); //this pause is for debugging only DELETE
 
+    bool success = true;
     //test for completion
     //TODO hook up to navigation stack here
-
     while (true)
     {
         //Deal with preemption or error
@@ -67,6 +69,7 @@ void Navigator::navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
             //cascade the preemption and wait
             ROS_INFO("%s: preempted", action_name.c_str());
             server.setPreempted();
+            success = false;
             break;
         }
         //main case, update nav goal
@@ -74,9 +77,9 @@ void Navigator::navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
         {
             if (goal_manager.location_code == tfr_msgs::NavigationGoal::TO_MINING)
             {
-                //grab local copy of shared ptr for safe shared memory
-                auto position = current_position;
-                goal_manager.update_mining_goal((*position).pose.pose);
+                //MAINTENENCE NOTE this is only safe to do if we are running on
+                //spin or spin once with no threaded callbacks
+                goal_manager.update_mining_goal(current_position.pose.pose);
                 //TODO send updated goal to navigation stack
             }
 
@@ -85,28 +88,34 @@ void Navigator::navigate(const tfr_msgs::NavigationGoalConstPtr &goal)
             feedback.header.stamp = ros::Time::now();
             feedback.header.frame_id = frame_id;
             feedback.status = tfr_msgs::NavigationFeedback::OK;
-            auto position = current_position;
-            feedback.current = (*position).pose.pose;
+            //MAINTENENCE NOTE this is only safe to do if we are running on
+            //spin or spin once with no threaded callbacks
+            feedback.current = current_position.pose.pose;
             feedback.goal = goal_manager.nav_goal.target_pose.pose;
             server.publishFeedback(feedback);
+            ROS_INFO("servicing goal, %f", feedback.header.stamp.toSec());
             r.sleep();
+            break; //debugging DELETE on integration
+
+
         }
     }
 
     //TODO hook up to navigation stack here
-    //test for success
-    if (true)
+    if (success)
     {
         result.header.stamp = ros::Time::now();
         result.header.frame_id = frame_id;
         result.status = tfr_msgs::NavigationResult::OK;
-        auto position = current_position;
-        result.current = (*position).pose.pose;
+        //MAINTENENCE NOTE this is only safe to do if we are running on
+        //spin or spin once with no threaded callbacks
+        result.current = current_position.pose.pose;
         result.goal = goal_manager.nav_goal.target_pose.pose;
         server.setSucceeded(result);
     }
-    else 
+    else if (false)
     {
+        //TODO hook error handling to navigation stack
         result.status = tfr_msgs::NavigationResult::OK;
         server.setAborted(result);
     }
@@ -122,5 +131,5 @@ void Navigator::update_position(const nav_msgs::OdometryConstPtr &msg)
     //get the pose without the covariance, not needed
     //need to use shared pointer here for thread safety see:
     //https://answers.ros.org/question/53234/processing-an-image-outside-the-callback-function/
-    current_position = msg;
+    current_position = *msg;
 }

--- a/src/tfr_navigation/test/test_goal_setting.cpp
+++ b/src/tfr_navigation/test/test_goal_setting.cpp
@@ -5,63 +5,82 @@
 #include <geometry_msgs/Pose.h>
 #include <iostream>
 
-TEST(GoalManager, miningDistance)
+//this is test code so sure whatev global defines are fine
+
+class GoalManager : public ::testing::Test
 {
-    ASSERT_TRUE(NavigationGoalManager::SAFE_MINING_DISTANCE > 0.66);
-    ASSERT_TRUE(NavigationGoalManager::SAFE_MINING_DISTANCE < 5.75);
+    protected:
+
+        virtual void SetUp()
+        {      
+        }
+
+        virtual void TearDown()
+        {
+        }
+        double SAFE_MINING_DISTANCE = 5.1;
+        double MINING_LINE_LENGTH = 2.03;
+        double FINISH_LINE = 0.84;
+
+};
+TEST_F(GoalManager, initializeMiningGoal)
+{
+    NavigationGoalManager::GeometryConstraints 
+        constraints(SAFE_MINING_DISTANCE, 
+                MINING_LINE_LENGTH, 
+                FINISH_LINE);
+    NavigationGoalManager manager(constraints, tfr_msgs::NavigationGoal::TO_MINING);
+    auto nav_goal = manager.initialize_goal();
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.x , 
+            SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.y , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.w ,0);
 }
 
-TEST(GoalManager, miningLineLength)
+TEST_F(GoalManager, initializeDumpingGoal)
 {
-    ASSERT_TRUE(NavigationGoalManager::MINING_LINE_LENGTH > 0);
-    ASSERT_TRUE(NavigationGoalManager::MINING_LINE_LENGTH <= 2.03);
+    NavigationGoalManager::GeometryConstraints 
+        constraints(SAFE_MINING_DISTANCE, 
+                MINING_LINE_LENGTH, 
+                FINISH_LINE);
+    NavigationGoalManager manager(constraints,
+            tfr_msgs::NavigationGoal::TO_DUMPING);
+    auto nav_goal = manager.initialize_goal();
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.x , 
+            FINISH_LINE);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.y , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.w ,0);
 }
 
-TEST(GoalManager, finishLineLength)
+TEST_F(GoalManager, badConstraints)
 {
-    ASSERT_TRUE(NavigationGoalManager::FINISH_LINE > 0.66);
-    ASSERT_TRUE(NavigationGoalManager::FINISH_LINE <= 6.84);
+    NavigationGoalManager::GeometryConstraints 
+        constraints(-1, 
+                MINING_LINE_LENGTH, 
+                FINISH_LINE);
+    NavigationGoalManager manager(constraints, tfr_msgs::NavigationGoal::TO_MINING);
+    std::cout << "Note: you should have seen a warning when running this" 
+        <<" test case, this is defined behavior." << std::endl;
 }
 
-TEST(GoalManager, defaultConstructor)
-{
-    NavigationGoalManager manager{};
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x, 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y, 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
-}
 
-TEST(GoalManager, constructorAndInitializer)
-{
-    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
-            NavigationGoalManager::SAFE_MINING_DISTANCE);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
-    manager.location_code = tfr_msgs::NavigationGoal::TO_DUMPING;
-    manager.initialize_goal();
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
-            NavigationGoalManager::FINISH_LINE);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
-}
 
-TEST(GoalManager, adjustMiningGoalNeg)
+TEST_F(GoalManager, adjustMiningGoalNeg)
 {
-    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
-    geometry_msgs::Pose p;
+    NavigationGoalManager::GeometryConstraints 
+        constraints(SAFE_MINING_DISTANCE, 
+                MINING_LINE_LENGTH, 
+                FINISH_LINE);
+    NavigationGoalManager manager(constraints, tfr_msgs::NavigationGoal::TO_MINING);
+    geometry_msgs::Pose p{};
     p.position.x = 3.4;
     p.position.y = -.05;
     p.position.z = 0.4;
@@ -69,21 +88,26 @@ TEST(GoalManager, adjustMiningGoalNeg)
     p.orientation.y = -.3;
     p.orientation.z = -.5;
     p.orientation.w = 1;
-    manager.update_mining_goal(p);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
-            NavigationGoalManager::SAFE_MINING_DISTANCE);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , -.05);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+    auto nav_goal = manager.get_updated_mining_goal(p);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.x , 
+            SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.y , -.05);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.w ,0);
 }
 
 
-TEST(GoalManager, adjustMiningGoalPos)
+TEST_F(GoalManager, adjustMiningGoalPos)
 {
-    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
+    NavigationGoalManager::GeometryConstraints 
+        constraints(
+                SAFE_MINING_DISTANCE, 
+                MINING_LINE_LENGTH, 
+                FINISH_LINE);
+    NavigationGoalManager manager(constraints, tfr_msgs::NavigationGoal::TO_MINING);
     geometry_msgs::Pose p;
     p.position.x = 3.4;
     p.position.y = 1;
@@ -92,20 +116,24 @@ TEST(GoalManager, adjustMiningGoalPos)
     p.orientation.y = -.3;
     p.orientation.z = -.5;
     p.orientation.w = 1;
-    manager.update_mining_goal(p);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
-            NavigationGoalManager::SAFE_MINING_DISTANCE);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 1);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+    auto nav_goal =  manager.get_updated_mining_goal(p);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.x , 
+            SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.y , 1);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.w ,0);
 }
 
-TEST(GoalManager, adjustMiningGoalBigPos)
+TEST_F(GoalManager, adjustMiningGoalBigPos)
 {
-    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
+    NavigationGoalManager::GeometryConstraints 
+        constraints(SAFE_MINING_DISTANCE, 
+                MINING_LINE_LENGTH, 
+                FINISH_LINE);
+    NavigationGoalManager manager(constraints, tfr_msgs::NavigationGoal::TO_MINING);
     geometry_msgs::Pose p;
     p.position.x = 3.4;
     p.position.y = 5;
@@ -114,20 +142,24 @@ TEST(GoalManager, adjustMiningGoalBigPos)
     p.orientation.y = -.3;
     p.orientation.z = -.5;
     p.orientation.w = 1;
-    manager.update_mining_goal(p);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
-            NavigationGoalManager::SAFE_MINING_DISTANCE);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 1.015);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+    auto nav_goal = manager.get_updated_mining_goal(p);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.x , 
+            SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.y , 1.015);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.w ,0);
 }
 
-TEST(GoalManager, adjustMiningGoalBigNeg)
+TEST_F(GoalManager, adjustMiningGoalBigNeg)
 {
-    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
+    NavigationGoalManager::GeometryConstraints 
+        constraints(SAFE_MINING_DISTANCE, 
+                MINING_LINE_LENGTH, 
+                FINISH_LINE);
+    NavigationGoalManager manager(constraints, tfr_msgs::NavigationGoal::TO_MINING);
     geometry_msgs::Pose p;
     p.position.x = 3.4;
     p.position.y = -5;
@@ -136,20 +168,25 @@ TEST(GoalManager, adjustMiningGoalBigNeg)
     p.orientation.y = -.3;
     p.orientation.z = -.5;
     p.orientation.w = 1;
-    manager.update_mining_goal(p);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
-            NavigationGoalManager::SAFE_MINING_DISTANCE);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , -1.015);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+    auto nav_goal = manager.get_updated_mining_goal(p);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.x , 
+            SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.y , -1.015);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.w ,0);
 }
 
-TEST(GoalManager, adjustMiningGoalWrongType)
+TEST_F(GoalManager, adjustMiningGoalWrongType)
 {
-    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_DUMPING);
+    NavigationGoalManager::GeometryConstraints 
+        constraints(SAFE_MINING_DISTANCE, 
+                MINING_LINE_LENGTH, 
+                FINISH_LINE);
+    NavigationGoalManager manager(constraints,
+            tfr_msgs::NavigationGoal::TO_DUMPING);
     geometry_msgs::Pose p;
     p.position.x = 3.4;
     p.position.y = -5;
@@ -158,15 +195,15 @@ TEST(GoalManager, adjustMiningGoalWrongType)
     p.orientation.y = -.3;
     p.orientation.z = -.5;
     p.orientation.w = 1;
-    manager.update_mining_goal(p);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
-            NavigationGoalManager::FINISH_LINE);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
-    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+    auto nav_goal = manager.get_updated_mining_goal(p);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.x , 
+            FINISH_LINE);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.y , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(nav_goal.target_pose.pose.orientation.w ,0);
     std::cout << "Note: you should have seen a warning when running this" 
         <<" test case, this is defined behavior." << std::endl;
 }

--- a/src/tfr_navigation/test/test_goal_setting.cpp
+++ b/src/tfr_navigation/test/test_goal_setting.cpp
@@ -1,0 +1,180 @@
+#include <gtest/gtest.h>
+#include <navigation_goal_manager.h>
+#include <tfr_msgs/NavigationAction.h>
+#include <move_base_msgs/MoveBaseAction.h>
+#include <geometry_msgs/Pose.h>
+#include <iostream>
+
+TEST(GoalManager, miningDistance)
+{
+    ASSERT_TRUE(NavigationGoalManager::SAFE_MINING_DISTANCE > 0.66);
+    ASSERT_TRUE(NavigationGoalManager::SAFE_MINING_DISTANCE < 5.75);
+}
+
+TEST(GoalManager, miningLineLength)
+{
+    ASSERT_TRUE(NavigationGoalManager::MINING_LINE_LENGTH > 0);
+    ASSERT_TRUE(NavigationGoalManager::MINING_LINE_LENGTH <= 2.03);
+}
+
+TEST(GoalManager, finishLineLength)
+{
+    ASSERT_TRUE(NavigationGoalManager::FINISH_LINE > 0.66);
+    ASSERT_TRUE(NavigationGoalManager::FINISH_LINE <= 6.84);
+}
+
+TEST(GoalManager, defaultConstructor)
+{
+    NavigationGoalManager manager{};
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x, 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y, 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+}
+
+TEST(GoalManager, constructorAndInitializer)
+{
+    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
+            NavigationGoalManager::SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+    manager.location_code = tfr_msgs::NavigationGoal::TO_DUMPING;
+    manager.initialize_goal();
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
+            NavigationGoalManager::FINISH_LINE);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+}
+
+TEST(GoalManager, adjustMiningGoalNeg)
+{
+    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
+    geometry_msgs::Pose p;
+    p.position.x = 3.4;
+    p.position.y = -.05;
+    p.position.z = 0.4;
+    p.orientation.x = .1;
+    p.orientation.y = -.3;
+    p.orientation.z = -.5;
+    p.orientation.w = 1;
+    manager.update_mining_goal(p);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
+            NavigationGoalManager::SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , -.05);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+}
+
+
+TEST(GoalManager, adjustMiningGoalPos)
+{
+    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
+    geometry_msgs::Pose p;
+    p.position.x = 3.4;
+    p.position.y = 1;
+    p.position.z = 0.4;
+    p.orientation.x = .1;
+    p.orientation.y = -.3;
+    p.orientation.z = -.5;
+    p.orientation.w = 1;
+    manager.update_mining_goal(p);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
+            NavigationGoalManager::SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 1);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+}
+
+TEST(GoalManager, adjustMiningGoalBigPos)
+{
+    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
+    geometry_msgs::Pose p;
+    p.position.x = 3.4;
+    p.position.y = 5;
+    p.position.z = 0.4;
+    p.orientation.x = .1;
+    p.orientation.y = -.3;
+    p.orientation.z = -.5;
+    p.orientation.w = 1;
+    manager.update_mining_goal(p);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
+            NavigationGoalManager::SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 1.015);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+}
+
+TEST(GoalManager, adjustMiningGoalBigNeg)
+{
+    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_MINING);
+    geometry_msgs::Pose p;
+    p.position.x = 3.4;
+    p.position.y = -5;
+    p.position.z = 0.4;
+    p.orientation.x = .1;
+    p.orientation.y = -.3;
+    p.orientation.z = -.5;
+    p.orientation.w = 1;
+    manager.update_mining_goal(p);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
+            NavigationGoalManager::SAFE_MINING_DISTANCE);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , -1.015);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+}
+
+TEST(GoalManager, adjustMiningGoalWrongType)
+{
+    NavigationGoalManager manager(tfr_msgs::NavigationGoal::TO_DUMPING);
+    geometry_msgs::Pose p;
+    p.position.x = 3.4;
+    p.position.y = -5;
+    p.position.z = 0.4;
+    p.orientation.x = .1;
+    p.orientation.y = -.3;
+    p.orientation.z = -.5;
+    p.orientation.w = 1;
+    manager.update_mining_goal(p);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.x ,
+            NavigationGoalManager::FINISH_LINE);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.y , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.position.z , 0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.x ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.y ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.z ,0);
+    ASSERT_DOUBLE_EQ(manager.nav_goal.target_pose.pose.orientation.w ,0);
+    std::cout << "Note: you should have seen a warning when running this" 
+        <<" test case, this is defined behavior." << std::endl;
+}
+
+
+int main(int argc, char **argv)
+{
+    ros::Time::init();
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/src/tfr_utilities/src/example_action_client.cpp
+++ b/src/tfr_utilities/src/example_action_client.cpp
@@ -60,6 +60,7 @@ int main(int argc, char** argv)
     goal.goal = "Do the thing!";
 
     // Callback functions: Result, Start, Feedback
+    //note we must use NULL not nullptr, or boost error
     client.sendGoal(goal, &finished, NULL, &feedback);
 
     ros::spin();


### PR DESCRIPTION
# Navigation Action Server
Contains the current client interface and "plumbing" of the navigation action server.

It consists of two nodes that wrap some encapsulating objects:

- Navigation Action Server:
  - The action  server that responds to user autonomous navigation requests. It contains a helper object called the navigation goal manager that manages goal state and goal updates. I did a separation of concerns here to make it more easily testable.
- Navigation Action Client:
  - This was a test node designed to show off the functionality of  it's contained Action Client and how it interacts with the action server. The idea being that later we can reuse the public interface of the action client in the executive node. What it tests and how will demonstrated in the testing section.

As an aside, all of the locations in the code that need further integration, or deletion when the navigation stack, or bin tf publisher is online, are given a `TODO` or `DELETE` comment annotation.

## Testing
There are ample unit tests for the navigation goal manager because it has the most mutable state, and does not rely on ros message passing.

There is a little bit of manual testing. I included a test launch file to demonstrate functionality.  Call it with `roslaunch tfr_launch navigation_as_test.launch`

Here is what it is supposed to do in sequence.
1. Spin up and action server
2. Spin up an action client
3. Start a goal
4. Preempt  that goal
5. Start a digging goal
6. Get feedback
7. Complete digging goal
9. Start Dumping goal
10. Get feedback
11. Finish Dumping goal