### PR TITLE
Update Jenkins badge to show current status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# NasaRmc2018 [![Build Status](http://40.65.120.141:8080/job/Jenkins%20Build%20-%20NasaRmc2018/31/badge/icon)](http://40.65.120.141:8080/job/Jenkins%20Build%20-%20NasaRmc2018/31/)
+# NasaRmc2018 [![Build Status](http://40.65.120.141:8080/job/Jenkins%20Build%20-%20NasaRmc2018/badge/icon)](http://40.65.120.141:8080/job/Jenkins%20Build%20-%20NasaRmc2018/)
+
+
 This is the primary codebase for all of the TrickFire Robotics Nasa RMC 2018 competition entry.
 
 # Installation


### PR DESCRIPTION
It currently shows the status of build 31, but it should show the current build status.