### PR TITLE
Added system codes

### DIFF
--- a/src/tfr_msgs/msg/SystemStatus.msg
+++ b/src/tfr_msgs/msg/SystemStatus.msg
@@ -1,3 +1,3 @@
 time time_stamp
-int32 status_code
+uint16 status_code
 float32 data

--- a/src/tfr_utilities/CMakeLists.txt
+++ b/src/tfr_utilities/CMakeLists.txt
@@ -51,6 +51,10 @@ include_directories(
   ${GTEST_INCLUDE_DIRS}
 )
 
+add_library(${PROJECT_NAME}
+  src/status_code.cpp
+)
+
 add_library(tf_manipulator
     ./src/tf_manipulator.cpp
 )
@@ -66,7 +70,9 @@ add_dependencies(bin_localizer ${catkin_EXPORTED_TARGETS})
 # This call is sometimes needed and sometimes not and I'm not really clear why
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
+
 # Add gtest based cpp test target and link libraries
+catkin_add_gtest(${PROJECT_NAME}-test test/test_system_codes.cpp)
 if(TARGET ${PROJECT_NAME}-test)
   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
 endif()

--- a/src/tfr_utilities/include/tfr_utilities/status_code.h
+++ b/src/tfr_utilities/include/tfr_utilities/status_code.h
@@ -1,0 +1,61 @@
+#ifndef STATUS_CODE_H
+#define STATUS_CODE_H
+
+#include <cstdint>
+#include <string>
+
+/**
+ * Definitions of Sub Systems.
+ *
+ * These codes use the top 8 bits to uniquely identify the sub system a
+ * particular status code belongs to and should never be changed.
+ */
+enum class SubSystem: uint16_t
+{
+    EXC = 0b0000000100000000,
+    LOC = 0b0000001000000000,
+    NAV = 0b0000010000000000,
+    MIN = 0b0000100000000000,
+    DMP = 0b0001000000000000
+};
+
+/**
+ * Defines the list of all status codes used by all Sub Systems.
+ *
+ * These codes consist of two parts:
+ *  - The top 8 bits which identify the sub system
+ *  - The bottom 8 bits which identify the status of the sub system
+ *
+ * When adding a new status code for a sub system, use the system identifier
+ * defined in the SubSystem enum class above and then increase the previous 8
+ * bit code by one. For example, if adding a new status code for the Executive
+ * sub system and the most recently added status code is 0b0000000100000000, the
+ * new status code should be defined as 0b0000000100000001.
+ *
+ * Don't forget to also add a message for any newly added status codes in
+ * status_code.cpp.
+ */
+enum class StatusCode : uint16_t
+{
+    //Executive Status Codes
+    EXC_OK = 0b0000000100000000,
+
+    //Localization Status Codes
+    LOC_OK = 0b0000001000000000,
+
+    //Navigation Status Codes
+    NAV_OK = 0b0000010000000000,
+
+    //Mining Status Codes
+    MIN_OK = 0b0000100000000000,
+
+    //Dumping Status Codes
+    DMP_OK = 0b0001000000000000
+};
+
+/**
+ * Get the status message from a status code and status data.
+ */
+std::string getStatusMessage(StatusCode code, float data);
+
+#endif

--- a/src/tfr_utilities/src/status_code.cpp
+++ b/src/tfr_utilities/src/status_code.cpp
@@ -1,0 +1,129 @@
+#include "status_code.h"
+
+//Defines the mask to use to identify a Sub System given a StatusCode
+enum { SystemMask = 0b1111111100000000 };
+
+/**
+ * Sub System specific getters for system messages.
+ *
+ * Any new status codes should have their associated messaged added into these
+ * functions.
+ */
+std::string parseExecCode(StatusCode code, float data);
+std::string parseLocCode(StatusCode code, float data);
+std::string parseNavCode(StatusCode code, float data);
+std::string parseMineCode(StatusCode code, float data);
+std::string parseDumpCode(StatusCode code, float data);
+
+
+std::string getStatusMessage(StatusCode code, float data)
+{
+    //switch to find the sub system and use associated code parser
+    switch (static_cast<SubSystem>(SystemMask & static_cast<uint16_t>(code)))
+    {
+        case SubSystem::EXC:
+        {
+            return parseExecCode(code, data);
+        }
+        case SubSystem::LOC:
+        {
+            return parseLocCode(code, data);
+        }
+        case SubSystem::NAV:
+        {
+            return parseNavCode(code, data);
+        }
+        case SubSystem::MIN:
+        {
+            return parseMineCode(code, data);
+        }
+        case SubSystem::DMP:
+        {
+            return parseDumpCode(code, data);
+        }
+        default:
+        {
+            return "Warning: Unknown sub system identifier received.";
+        }
+    }
+}
+
+//Parser for all status codes in the Executive sub system
+std::string parseExecCode(StatusCode code, float data)
+{
+    switch(code)
+    {
+        case StatusCode::EXC_OK:
+        {
+            return "Executive System OK";
+        }
+        default:
+        {
+            return "Warning: Unknown status code for Executive received.";
+        }
+    }
+}
+
+//Parser for all status codes in the Localization sub system
+std::string parseLocCode(StatusCode code, float data)
+{
+    switch(code)
+    {
+        case StatusCode::LOC_OK:
+        {
+            return "Localization System OK";
+        }
+        default:
+        {
+            return "Warning: Unknown status code for Localization received.";
+        }
+    }
+}
+
+//Parser for all status codes in the Navigation sub system
+std::string parseNavCode(StatusCode code, float data)
+{
+    switch(code)
+    {
+        case StatusCode::NAV_OK:
+        {
+            return "Navigation System OK";
+        }
+        default:
+        {
+            return "Warning: Unknown status code for Navigation received.";
+        }
+    }
+}
+
+//Parser for all status codes in the Mining sub system
+std::string parseMineCode(StatusCode code, float data)
+{
+    switch(code)
+    {
+        case StatusCode::MIN_OK:
+        {
+            return "Mining System OK";
+        }
+        default:
+        {
+            return "Warning: Unknown status code for Mining received.";
+        }
+    }
+}
+
+//Parser for all status codes in the Dumping sub system
+std::string parseDumpCode(StatusCode code, float data)
+{
+    switch(code)
+    {
+        case StatusCode::DMP_OK:
+        {
+            return "Dumping System OK";
+        }
+        default:
+        {
+            return "Warning: Unknown status code for Dumping received.";
+        }
+    }
+}

--- a/src/tfr_utilities/test/test_system_codes.cpp
+++ b/src/tfr_utilities/test/test_system_codes.cpp
@@ -1,0 +1,16 @@
+#include <gtest/gtest.h>
+#include "status_code.h"
+
+TEST(SystemCodes, Basic)
+{
+
+	std::string message = getStatusMessage(StatusCode::NAV_OK, 0);
+	ASSERT_EQ(message, "Navigation System OK");
+
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### About:
This pull adds enums describing the sub systems and their status codes, where the status codes are any status the system could be in. It also adds functions that parse and generate the system messages.

The idea here is for each sub system maintainer to add a new status to the `StatusCode` enum class and to then add an accompanying string message in that system's parse function.

The status code width was changed from 32 to 16 bits, where the higher order byte represents the sub system relaying the message and the lower order byte represents a status for that sub system. This gives each sub system the ability to have 256 different statuses.

I've also removed the original utilities placeholder, and then updated `mining_echo.cpp` which relied on it. This shows what using the status message and status code in a sub system would be like. It might be a good idea to add a helper function for this to avoid needed to do the cast inline.

### Testing:
There is a simple test that was added to the Utilities package just to show that the system will switch correctly. I didn't feel the need to add a test for all cases.

### Notes:
This design would work, but I'm not entirely happy with it. Feedback would be appreciated.