### PR TITLE
Hole Obstacle

### DIFF
--- a/src/tfr_launch/launch/hole_test.launch
+++ b/src/tfr_launch/launch/hole_test.launch
@@ -1,5 +1,5 @@
 <launch>
     <include file="$(find tfr_navigation)/launch/hole_broadcaster.launch"/>
     <node name="hole_test" pkg="tfr_utilities" type="obstacle_test" output="screen"/>
-    <node name="rviz" pkg="rviz" type="rviz"/>
+    <include file="$(find tfr_visualization)/launch/hole.launch"/>
 </launch>

--- a/src/tfr_launch/launch/hole_test.launch
+++ b/src/tfr_launch/launch/hole_test.launch
@@ -1,0 +1,5 @@
+<launch>
+    <include file="$(find tfr_navigation)/launch/hole_broadcaster.launch"/>
+    <node name="hole_test" pkg="tfr_utilities" type="obstacle_test" output="screen"/>
+    <node name="rviz" pkg="rviz" type="rviz"/>
+</launch>

--- a/src/tfr_navigation/launch/hole_broadcaster.launch
+++ b/src/tfr_navigation/launch/hole_broadcaster.launch
@@ -1,5 +1,4 @@
 <launch>
-    <!--spins up a settable broadcaster for the location of the bin-->
     <node name="hole_broadcaster" pkg="tfr_utilities" output="screen" type="obstacle_broadcaster">
         <rosparam>
             parent_frame: odom

--- a/src/tfr_navigation/launch/hole_broadcaster.launch
+++ b/src/tfr_navigation/launch/hole_broadcaster.launch
@@ -1,0 +1,12 @@
+<launch>
+    <!--spins up a settable broadcaster for the location of the bin-->
+    <node name="hole_broadcaster" pkg="tfr_utilities" output="screen" type="obstacle_broadcaster">
+        <rosparam>
+            parent_frame: odom
+            point_frame: hole
+            service_name: localize_hole
+            hz: 10
+            diameter: 0.5
+        </rosparam>
+    </node>
+</launch>

--- a/src/tfr_utilities/CMakeLists.txt
+++ b/src/tfr_utilities/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
   tf2_ros
   tf2_geometry_msgs
+  pcl_ros
 )
 
 find_package(GTest REQUIRED)
@@ -68,9 +69,19 @@ add_executable(point_broadcaster src/point_broadcaster.cpp)
 target_link_libraries(point_broadcaster ${catkin_LIBRARIES})
 add_dependencies(point_broadcaster ${catkin_EXPORTED_TARGETS})
 
+add_executable(obstacle_broadcaster src/obstacle_broadcaster.cpp)
+target_link_libraries(obstacle_broadcaster ${catkin_LIBRARIES})
+add_dependencies(obstacle_broadcaster ${catkin_EXPORTED_TARGETS})
+
+
 add_executable(bin_localizer src/bin_localizer.cpp)
 target_link_libraries(bin_localizer tf_manipulator ${catkin_LIBRARIES})
 add_dependencies(bin_localizer ${catkin_EXPORTED_TARGETS})
+
+add_executable(obstacle_test src/obstacle_test.cpp)
+target_link_libraries(obstacle_test ${catkin_LIBRARIES})
+add_dependencies(obstacle_test ${catkin_EXPORTED_TARGETS})
+
 
 # This call is sometimes needed and sometimes not and I'm not really clear why
 SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")

--- a/src/tfr_utilities/include/tfr_utilities/obstacle_broadcaster.h
+++ b/src/tfr_utilities/include/tfr_utilities/obstacle_broadcaster.h
@@ -15,15 +15,16 @@
  *  When initialized will drop a circular obstacle into the field with configurable diameter.
  *
  *  Listens for updates on a service. The service takes in a tfr_msgs/LocalizePoint.srv
- *
- *  It will report (0 0 0) (0 0 0 0) until it is given a proper location
+ *  Once it gets called it will broadcast the obstacle at wherever the service
+ *  told it to go
  *
  *  parameters:
- *      parent_frame: the parent frame of this point (type = string, default = "")
- *      point_frame: the name of the frame you want to broadcast (type = string, default = "")
- *      service_name: the name of the service you want to broadcast (type = string, default = "")
- *      hz: the frequency to pubish at. (type = double, default: 5.0)
- *      diameter: the diameter of the obstacle in meters (type = double, default: 0.0)
+ *      ~parent_frame: the parent frame of this point (type = string, default = "")
+ *      ~point_frame: the name of the frame you want to broadcast (type = string, default = "")
+ *      ~service_name: the name of the service you want to broadcast (type = string, default = "")
+ *      ~hz: the frequency to pubish at. (type = double, default: 5.0)
+ *      ~diameter: the diameter of the obstacle in meters (type = double, default: 0.0)
+ *
  *  published topics:
  *      obstacle_cloud (PointCloud2) the cloud of points representing the obstacle
  * */
@@ -46,7 +47,6 @@ class ObstacleBroadcaster
         void broadcast();
 
     private:
-        typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
         ros::NodeHandle &node;
         tf2_ros::TransformBroadcaster broadcaster{};
         ros::Publisher cloud_publisher{};
@@ -60,6 +60,6 @@ class ObstacleBroadcaster
 
         bool localizePoint(tfr_msgs::LocalizePoint::Request &request,
                 tfr_msgs::LocalizePoint::Response &response);
-        void generateCloud(PointCloud &cloud);
+        void generateCloud(pcl::PointCloud<pcl::PointXYZ> &cloud);
 };
 #endif

--- a/src/tfr_utilities/include/tfr_utilities/obstacle_broadcaster.h
+++ b/src/tfr_utilities/include/tfr_utilities/obstacle_broadcaster.h
@@ -1,0 +1,59 @@
+#ifndef OBSTACLE_BROADCASTER_H 
+#define OBSTACLE_BROADCASTER_H 
+
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <geometry_msgs/TransformStamped.h>
+#include <tfr_msgs/LocalizePoint.h>
+#include <pcl_ros/point_cloud.h>
+#include <pcl/point_types.h>
+#include <math.h>
+/**
+ *  Utility node
+ *
+ *  When initialized will drop a circular obstacle into the field with configurable diameter.
+ *
+ *  Listens for updates on a service. The service takes in a tfr_msgs/LocalizePoint.srv
+ *
+ *  It will report (0 0 0) (0 0 0 0) until it is given a proper location
+ *
+ *  parameters:
+ *      parent_frame: the parent frame of this point (type = string, default = "")
+ *      point_frame: the name of the frame you want to broadcast (type = string, default = "")
+ *      service_name: the name of the service you want to broadcast (type = string, default = "")
+ *      hz: the frequency to pubish at. (type = double, default: 5.0)
+ *      diameter: the diameter of the obstacle in meters (type = double, default: 0.0)
+ * */
+class ObstacleBroadcaster 
+{
+    public:
+        ObstacleBroadcaster(ros::NodeHandle &n, const std::string &point_frame, const  std::string
+                &parent_frame, const std::string &service, const double &diameter);
+        ~ObstacleBroadcaster(){};
+
+        ObstacleBroadcaster(const ObstacleBroadcaster&) = delete;
+        ObstacleBroadcaster& operator=( const ObstacleBroadcaster&) = delete;
+        ObstacleBroadcaster(ObstacleBroadcaster&&) = delete;
+        ObstacleBroadcaster& operator=(ObstacleBroadcaster&&) = delete;
+
+        void broadcast();
+
+    private:
+        typedef pcl::PointCloud<pcl::PointXYZ> PointCloud;
+        ros::NodeHandle &node;
+        tf2_ros::TransformBroadcaster broadcaster{};
+        ros::Publisher cloud_publisher{};
+        geometry_msgs::TransformStamped transform{};
+        ros::ServiceServer server;
+        const std::string &broadcaster_frame;
+        const std::string &map_frame;
+        const std::string &service_name;
+        const double &diameter;
+        bool point_set;
+
+        bool localizePoint(tfr_msgs::LocalizePoint::Request &request,
+                tfr_msgs::LocalizePoint::Response &response);
+        void generateCloud(PointCloud &cloud);
+};
+#endif

--- a/src/tfr_utilities/include/tfr_utilities/obstacle_broadcaster.h
+++ b/src/tfr_utilities/include/tfr_utilities/obstacle_broadcaster.h
@@ -24,12 +24,18 @@
  *      service_name: the name of the service you want to broadcast (type = string, default = "")
  *      hz: the frequency to pubish at. (type = double, default: 5.0)
  *      diameter: the diameter of the obstacle in meters (type = double, default: 0.0)
+ *  published topics:
+ *      obstacle_cloud (PointCloud2) the cloud of points representing the obstacle
  * */
 class ObstacleBroadcaster 
 {
     public:
-        ObstacleBroadcaster(ros::NodeHandle &n, const std::string &point_frame, const  std::string
-                &parent_frame, const std::string &service, const double &diameter);
+        ObstacleBroadcaster(
+                ros::NodeHandle &n, 
+                const std::string &point_frame, 
+                const  std::string &parent_frame, 
+                const std::string &service, 
+                const double &diameter);
         ~ObstacleBroadcaster(){};
 
         ObstacleBroadcaster(const ObstacleBroadcaster&) = delete;

--- a/src/tfr_utilities/package.xml
+++ b/src/tfr_utilities/package.xml
@@ -25,5 +25,6 @@
   <depend>tf2_ros</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>actionlib</depend>
+  <depend>pcl_ros</depend>
 
 </package>

--- a/src/tfr_utilities/src/obstacle_broadcaster.cpp
+++ b/src/tfr_utilities/src/obstacle_broadcaster.cpp
@@ -1,0 +1,102 @@
+#include <obstacle_broadcaster.h>
+
+/*
+ * Initializes the broadcaster and data structures
+ * */
+ObstacleBroadcaster::ObstacleBroadcaster(
+        ros::NodeHandle& n, 
+        const std::string &point_frame, 
+        const std::string &parent_frame, 
+        const std::string &service,
+        const double &d) : 
+
+    node{n}, 
+    broadcaster_frame{point_frame},
+    map_frame{parent_frame}, 
+    service_name{service},
+    diameter{d},
+    point_set{false}
+{
+    server = node.advertiseService(service_name,
+            &ObstacleBroadcaster::localizePoint, this);
+    transform.header.frame_id = map_frame;
+    transform.child_frame_id = broadcaster_frame;
+    transform.transform.rotation.w = 1;
+    cloud_publisher = node.advertise<sensor_msgs::PointCloud2>("hole", 5);
+}
+
+/*
+ * Broadcasts point across the transform network
+ * If the point has been set it will also broadcast the obstacle
+ * */
+void ObstacleBroadcaster::broadcast()
+{
+    transform.header.stamp = ros::Time::now();
+    broadcaster.sendTransform(transform);
+    if (point_set)
+    {
+        PointCloud cloud;
+        generateCloud(cloud);
+        cloud_publisher.publish(cloud);
+    }
+}
+
+/*
+ * Gives the point a new origin
+ * */
+bool ObstacleBroadcaster::localizePoint(tfr_msgs::LocalizePoint::Request &request,
+        tfr_msgs::LocalizePoint::Response &resonse)
+{
+    transform.transform.translation.x = request.pose.pose.position.x;
+    transform.transform.translation.y = request.pose.pose.position.y;
+    transform.transform.translation.z = request.pose.pose.position.z;
+    transform.transform.rotation.x = request.pose.pose.orientation.x;
+    transform.transform.rotation.y = request.pose.pose.orientation.y;
+    transform.transform.rotation.z = request.pose.pose.orientation.z;
+    transform.transform.rotation.w = request.pose.pose.orientation.w;
+    point_set = true;
+    return true;
+}
+
+/*
+ *  Generates a circular pointcloud levitating above the ground around the hole,
+ *  used to make sure the robot, never ever falls in.
+ * */
+void ObstacleBroadcaster::generateCloud(PointCloud &cloud)
+{
+    double PI = 3.14159;
+    cloud.header.frame_id = broadcaster_frame;
+    cloud.width    = 16;
+    cloud.height   = 1;
+    for (int i = 0, offset = 0;  i < 16; i++, offset += PI/8) 
+        cloud.points.push_back(pcl::PointXYZ( cos(offset), sin(offset), 1));
+
+}
+
+
+int main(int argc, char** argv)
+{
+    ros::init(argc, argv, "point_broadcaster");
+    ros::NodeHandle n;
+
+    //get parameters
+    std::string point_frame{}, parent_frame{}, service_name{};
+    double hz{}, diameter{};
+
+    ros::param::param<std::string>("~parent_frame", parent_frame, "");
+    ros::param::param<std::string>("~point_frame", point_frame, "");
+    ros::param::param<std::string>("~service_name", service_name, "");
+    ros::param::param<double>("~hz", hz, 5.0 );
+    ros::param::param<double>("~diameter", diameter, 0.0 );
+
+    ObstacleBroadcaster broadcaster{n, point_frame, parent_frame, service_name, diameter};
+
+    //broadcast the point across the network
+    ros::Rate rate(hz);
+    while(ros::ok())
+    {
+        broadcaster.broadcast();
+        ros::spinOnce();
+        rate.sleep();
+    }
+}

--- a/src/tfr_utilities/src/obstacle_broadcaster.cpp
+++ b/src/tfr_utilities/src/obstacle_broadcaster.cpp
@@ -22,7 +22,7 @@ ObstacleBroadcaster::ObstacleBroadcaster(
     transform.header.frame_id = map_frame;
     transform.child_frame_id = broadcaster_frame;
     transform.transform.rotation.w = 1;
-    cloud_publisher = node.advertise<sensor_msgs::PointCloud2>("hole", 5);
+    cloud_publisher = node.advertise<sensor_msgs::PointCloud2>("obstacle_cloud", 5);
 }
 
 /*
@@ -68,8 +68,13 @@ void ObstacleBroadcaster::generateCloud(PointCloud &cloud)
     cloud.header.frame_id = broadcaster_frame;
     cloud.width    = 16;
     cloud.height   = 1;
-    for (int i = 0, offset = 0;  i < 16; i++, offset += PI/8) 
-        cloud.points.push_back(pcl::PointXYZ( cos(offset), sin(offset), 1));
+    cloud.is_dense = false;
+    double radius = diameter/2, offset = 0.0;
+    for (int i = 0;  i < 16; i++, offset += PI/8) 
+    {
+        cloud.points.push_back(pcl::PointXYZ( radius*cos(offset), radius*sin(offset), 0.1));
+        ROS_INFO("%f, %f, %f, %f", offset, radius*cos(offset), radius*sin(offset), 0.1);
+    }
 
 }
 

--- a/src/tfr_utilities/src/obstacle_test.cpp
+++ b/src/tfr_utilities/src/obstacle_test.cpp
@@ -14,6 +14,7 @@ int main(int argc, char **argv)
     ros::Duration(3).sleep();
     //send the message
     tfr_msgs::LocalizePoint::Request request;
+    request.pose.pose.position.x=0.5;
     request.pose.pose.orientation.z=1;
     tfr_msgs::LocalizePoint::Response response;
         ros::service::call("localize_hole", request, response);

--- a/src/tfr_utilities/src/obstacle_test.cpp
+++ b/src/tfr_utilities/src/obstacle_test.cpp
@@ -11,10 +11,11 @@ int main(int argc, char **argv)
 {
     ros::init(argc, argv, "bin_localizer");
     ros::NodeHandle n{};
-
+    ros::Duration(3).sleep();
     //send the message
     tfr_msgs::LocalizePoint::Request request;
+    request.pose.pose.orientation.z=1;
     tfr_msgs::LocalizePoint::Response response;
-    bool out = ros::service::call("localize_hole", request, response);
+        ros::service::call("localize_hole", request, response);
     return 0;
 }

--- a/src/tfr_utilities/src/obstacle_test.cpp
+++ b/src/tfr_utilities/src/obstacle_test.cpp
@@ -1,0 +1,20 @@
+/**
+ * Test code never to be seen again to be used for testing the obstacle
+ * broadcaster
+ * */
+
+#include <ros/ros.h>
+#include <ros/console.h>
+#include <tfr_msgs/LocalizePoint.h>
+
+int main(int argc, char **argv)
+{
+    ros::init(argc, argv, "bin_localizer");
+    ros::NodeHandle n{};
+
+    //send the message
+    tfr_msgs::LocalizePoint::Request request;
+    tfr_msgs::LocalizePoint::Response response;
+    bool out = ros::service::call("localize_hole", request, response);
+    return 0;
+}

--- a/src/tfr_visualization/config/hole.rviz
+++ b/src/tfr_visualization/config/hole.rviz
@@ -1,0 +1,164 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /PointCloud21
+      Splitter Ratio: 0.5
+    Tree Height: 531
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.588679016
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: PointCloud2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.0299999993
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: x
+      Class: rviz/PointCloud2
+      Color: 255; 0; 0
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 0.25
+      Min Color: 0; 0; 0
+      Min Intensity: -0.25
+      Name: PointCloud2
+      Position Transformer: XYZ
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.00999999978
+      Style: Flat Squares
+      Topic: /obstacle_cloud
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Class: rviz/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        hole:
+          Value: true
+        odom:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        odom:
+          hole:
+            {}
+      Update Interval: 0
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 238; 238; 238
+    Default Light: true
+    Fixed Frame: odom
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Topic: /initialpose
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 2.2817142
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.0599999987
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: -0.107691094
+        Y: 0.334672421
+        Z: 0.269576222
+      Focal Shape Fixed Size: false
+      Focal Shape Size: 0.0500000007
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.00999999978
+      Pitch: 0.645204008
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 1.17221248
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 744
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000016a000002a2fc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000006100fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000028000002a2000000d700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000000c00430061006d00650072006100000003ec000000160000000000000000fb0000000c00430061006d0065007200610100000334000000ce0000000000000000000000010000010f000002e2fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a005600690065007700730000000028000002e2000000ad00fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000006400000003efc0100000002fb0000000800540069006d00650000000000000006400000030000fffffffb0000000800540069006d00650100000000000004500000000000000000000003e6000002a200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1366
+  X: 0
+  Y: 24

--- a/src/tfr_visualization/launch/hole.launch
+++ b/src/tfr_visualization/launch/hole.launch
@@ -1,0 +1,4 @@
+<launch>
+  <node name="rviz" pkg="rviz" type="rviz" args="-d $(find tfr_visualization)/config/hole.rviz"/>
+</launch>
+


### PR DESCRIPTION
# Description
Wrote a node that can generate circular obstacles as pointclouds with a given radius. 

Simple call a service to activate it, then it will broadcast until the end of time. 

See the header `obstacle_broadcaster.h` in `tfr_utilities` for full documentation.

Test it with:
`roslaunch tfr_launch hole_test.launch`