### PR TITLE
Add setup files for networking support

### DIFF
--- a/src/tfr_launch/launch/mission_control_test.launch
+++ b/src/tfr_launch/launch/mission_control_test.launch
@@ -1,5 +1,3 @@
 <launch>
     <node name="mission_control" pkg="tfr_mission_control" type="tfr_mission_control" output="screen"/>
-    <node name="motor_toggle_test" pkg="tfr_control" type="motor_toggle_test" output="screen"/>
-    <include file="$(find tfr_executive)/launch/executive.launch"/>
 </launch>

--- a/src/tfr_launch/launch/motor_toggle_test.launch
+++ b/src/tfr_launch/launch/motor_toggle_test.launch
@@ -1,0 +1,4 @@
+<launch>
+    <node name="motor_toggle_test" pkg="tfr_control" type="motor_toggle_test" output="screen"/>
+    <include file="$(find tfr_executive)/launch/executive.launch"/>
+</launch>

--- a/start_mission_control.sh
+++ b/start_mission_control.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+export ROS_MASTER_URI=http://192.168.1.3:11311
+export ROS_IP=192.168.1.4
+
+#roslaunch for mission control goes here

--- a/start_robot.sh
+++ b/start_robot.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+export ROS_MASTER_URI=http://192.168.1.3:11311
+export ROS_IP=192.168.1.3
+
+#roslaunch for robot goes here


### PR DESCRIPTION
This commit adds two files in the top level directory which are intended to be the "boot" scripts for both the robot and mission control. These export the needed IP information needed for networking, and will later call the right roslaunch commands to initialize the systems.

I also split the mission control launch file into two parts as part of testing.